### PR TITLE
chore: add a new build_cache hash

### DIFF
--- a/adm2/Makefile
+++ b/adm2/Makefile
@@ -1,4 +1,4 @@
-BINS=_launch_crontab clear.sh metwork_debug _doc_layer.sh _yaml_to_md.py
+BINS=_launch_crontab clear.sh metwork_debug _doc_layer.sh _yaml_to_md.py _build_cache_hash.sh
 SHARES=_metwork.spec
 
 include ../adm/root.mk

--- a/adm2/_build_cache_hash.sh
+++ b/adm2/_build_cache_hash.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${DIR}/.."
+
+git ls-tree HEAD |grep -v "README.md" |grep -v "CHANGELOG.md" >/tmp/build_cache_hash.$$
+if test -f /etc/buildimage_hash; then
+    cat /etc/buildimage_hash >>/tmp/build_cache_hash.$$
+fi
+cat "${DIR}/../adm/root.mk" |grep _HOME >>/tmp/build_cache_hash.$$
+
+cat /tmp/build_cache_hash.$$ |md5sum |awk '{print $1;}'
+rm -f /tmp/build_cache_hash.$$


### PR DESCRIPTION
The idea is to have a better build_cache hash (for example, this one
ignores CHANGELOG.md changes). This is the beginning of a bigger change.
In this commit, we just introduce a tool (but it's not used for the
moment).