### PR TITLE
build: ignore all .md and .yml files for computing build hash

### DIFF
--- a/adm2/_build_cache_hash.sh
+++ b/adm2/_build_cache_hash.sh
@@ -10,7 +10,7 @@ fi
 SRCDIR=$(readlink -f "${SRCDIR}")
 cd "${SRCDIR}"
 
-git ls-tree HEAD |grep -v "README.md" |grep -v "CHANGELOG.md" >/tmp/build_cache_hash.$$
+git ls-tree HEAD |grep -v '\.git' |grep -v '.md$' |grep -v '.yml$' >/tmp/build_cache_hash.$$
 if test -f /etc/buildimage_hash; then
     cat /etc/buildimage_hash >>/tmp/build_cache_hash.$$
 fi


### PR DESCRIPTION
The .git* files are also ignored