### PR TITLE
build: potentially faster build for ci_* branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,11 +2,11 @@ bootstrap_common: &bootstrap_common
   pull: true
   commands:
     - if test "$${FORCED_OS_VERSION}" != ""; then if test "$${FORCED_OS_VERSION}" != "${OS_VERSION}"; then echo "step bypass"; exit 0; fi; fi
-    - mkdir -p /opt/metwork-mfext-${DRONE_BRANCH}
-    - ./bootstrap.sh /opt/metwork-mfext-${DRONE_BRANCH}
+    - mkdir -p /opt/metwork-mfext-$${TARGET_BRANCH}
+    - ./bootstrap.sh /opt/metwork-mfext-$${TARGET_BRANCH}
     - cat adm/root.mk
     - CACHE_HASH=`./adm2/_build_cache_hash.sh .`
-    - if ! test -f /buildcache/build_mfext_${DRONE_BRANCH}_$${CACHE_HASH}; then echo $${CACHE_HASH} >.drone_cache; fi
+    - if ! test -f /buildcache/build_mfext_$${TARGET_BRANCH}_$${CACHE_HASH}; then echo $${CACHE_HASH} >.drone_cache; fi
   volumes:
     - /buildcache:/buildcache
 
@@ -15,15 +15,15 @@ build_common: &build_common
     - if test "$${FORCED_OS_VERSION}" != ""; then if test "$${FORCED_OS_VERSION}" != "${OS_VERSION}"; then echo "step bypass"; exit 0; fi; fi
     - if ! test -f .drone_cache; then echo "build bypass"; exit 0; fi
     - export METWORK_BUILD_OS=${OS_VERSION}
-    - mkdir -p /opt/metwork-mfext-${DRONE_BRANCH}
+    - mkdir -p /opt/metwork-mfext-$${TARGET_BRANCH}
     - mkdir -p /pub/metwork/continuous_integration/buildlogs/${DRONE_BRANCH}/mfext/${OS_VERSION}/${DRONE_BUILD_NUMBER}
     - make >/pub/metwork/continuous_integration/buildlogs/${DRONE_BRANCH}/mfext/${OS_VERSION}/${DRONE_BUILD_NUMBER}/make.log 2>&1
     - make doc >>/pub/metwork/continuous_integration/buildlogs/${DRONE_BRANCH}/mfext/${OS_VERSION}/${DRONE_BUILD_NUMBER}/make.log 2>&1
     - rm -Rf html_doc
-    - cp -Rf /opt/metwork-mfext-${DRONE_BRANCH}/html_doc .
+    - cp -Rf /opt/metwork-mfext-$${TARGET_BRANCH}/html_doc .
     - make test >>/pub/metwork/continuous_integration/buildlogs/${DRONE_BRANCH}/mfext/${OS_VERSION}/${DRONE_BUILD_NUMBER}/make.log 2>&1
     - make RELEASE_BUILD=${DRONE_BUILD_NUMBER} rpm >>/pub/metwork/continuous_integration/buildlogs/${DRONE_BRANCH}/mfext/${OS_VERSION}/${DRONE_BUILD_NUMBER}/make.log 2>&1
-    - mv /opt/metwork-mfext-${DRONE_BRANCH}/*.rpm .
+    - mv /opt/metwork-mfext-$${TARGET_BRANCH}/*.rpm .
   volumes:
     - /pub:/pub
     - /buildcache:/buildcache
@@ -36,7 +36,7 @@ publish_ci_common: &publish_ci_common
     - cp *.rpm /pub/metwork/continuous_integration/rpms/${DRONE_BRANCH}/${OS_VERSION}/
     - createrepo --update /pub/metwork/continuous_integration/rpms/${DRONE_BRANCH}/${OS_VERSION}
     - if test "${OS_VERSION}" = "centos6"; then rm -Rf /pub/metwork/continuous_integration/docs/${DRONE_BRANCH}/mfext; mkdir -p /pub/metwork/continuous_integration/docs/${DRONE_BRANCH}/mfext ; cp -Rf html_doc/* /pub/metwork/continuous_integration/docs/${DRONE_BRANCH}/mfext/ ; fi
-    - touch /buildcache/build_mfext_${DRONE_BRANCH}_`cat .drone_cache`
+    - touch /buildcache/build_mfext_$${TARGET_BRANCH}_`cat .drone_cache`
   volumes:
     - /pub:/pub
     - /buildcache:/buildcache
@@ -44,37 +44,65 @@ publish_ci_common: &publish_ci_common
 pipeline:
   bootstrap_integration:
     image: metwork/mfext-${OS_VERSION}-buildimage:integration
+    environment:
+      - TARGET_BRANCH=integration
     <<: *bootstrap_common
     when:
       event: push
       branch: integration
-  bootstrap:
+  bootstrap_ci:
     image: metwork/mfext-${OS_VERSION}-buildimage:master
+    environment:
+      - TARGET_BRANCH=integration
     <<: *bootstrap_common
     when:
       event: push
-      branch: [ master, ci_*, pci_* ]
+      branch: [ ci_* ]
+  bootstrap:
+    image: metwork/mfext-${OS_VERSION}-buildimage:master
+    environment:
+      - TARGET_BRANCH=${DRONE_BRANCH}
+    <<: *bootstrap_common
+    when:
+      event: push
+      branch: [ master, pci_* ]
   build_integration_push:
     <<: *build_common
     image: metwork/mfext-${OS_VERSION}-buildimage:integration
+    environment:
+      - TARGET_BRANCH=integration
     when:
       event: push
       branch: integration
-  build:
+  build_ci:
     image: metwork/mfext-${OS_VERSION}-buildimage:master
+    environment:
+      - TARGET_BRANCH=integration
     <<: *build_common
     when:
       event: push
-      branch: [ master, ci_*, pci_* ]
+      branch: [ ci_* ]
+  build:
+    image: metwork/mfext-${OS_VERSION}-buildimage:master
+    environment:
+      - TARGET_BRANCH=${DRONE_BRANCH}
+    <<: *build_common
+    when:
+      event: push
+      branch: [ master, pci_* ]
   publish_ci_integration:
     <<: *publish_ci_common
     image: metwork/mfext-${OS_VERSION}-buildimage:integration
+    environment:
+      - TARGET_BRANCH=integration
     when:
       event: push
       branch: integration
   publish_ci:
     <<: *publish_ci_common
     image: metwork/mfext-${OS_VERSION}-buildimage:master
+    environment:
+      - TARGET_BRANCH=${DRONE_BRANCH}
     when:
       event: push
       branch: [ master, pci_* ]


### PR DESCRIPTION
In the specific case of ci_* branches, we try to build them into
"integration" paths to potentially use build caches.