### PR TITLE
build: add a FORCED_OS_VERSION parameter

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -121,6 +121,8 @@ pipeline:
     pull: true
     repositories:
       - metwork-framework/mfext-integration-tests@${DRONE_BRANCH}
+    params:
+      - FORCED_OS_VERSION=${OS_VERSION}
     secrets: [ downstream_token, downstream_server ]
     when:
       status: [ success ]


### PR DESCRIPTION
The idea is to avoid too many builds of mfext-integration-tests