### PR TITLE
feat: Add possibility to pip install package from https url.

### DIFF
--- a/layers/_pip_package_to_yaml.sh
+++ b/layers/_pip_package_to_yaml.sh
@@ -16,11 +16,13 @@ if test "${2:-}" = ""; then
 fi
 
 PACKAGE="$1"
-N=$(echo "${PACKAGE}" |grep -c "^\\-e git+http" || true)
+N=$(echo "${PACKAGE}" |grep -c -E "^\\-e git+http|^\\https" || true)
 SOURCE=
 if test "${N}" -gt 0; then
     # this is a link like
     # -e git+https://github.com/Hawker65/deploycron.git@8fc7c4b8b072d7be7fb27517c9640bd1846b2ed9#egg=deploycron
+    # or
+    # https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz#egg=basemap
     SOURCE=$(echo "${PACKAGE}" |awk -F "#egg=" '{print $1;}' |sed 's/^-e //g')
     PACKAGE=$(echo "${PACKAGE}" |awk -F "#egg=" '{print $2;}')
     if test "${PACKAGE}" = ""; then

--- a/layers/layer1_python3_core/0000_adm/download_compile_requirements
+++ b/layers/layer1_python3_core/0000_adm/download_compile_requirements
@@ -48,7 +48,7 @@ if test "${N}" -eq 0; then
 fi
 
 # shellcheck disable=SC2086
-pip wheel --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --disable-pip-version-check --wheel-dir=./src --src=./tmp_src --no-binary :all: -r "${REQUIREMENTS}" ${CONSTRAINT} >&2
+pip wheel --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host downloads.sourceforge.net --disable-pip-version-check --wheel-dir=./src --src=./tmp_src --no-binary :all: -r "${REQUIREMENTS}" ${CONSTRAINT} >&2
 rm -Rf tmp_src
 
 rm -Rf "${TEMPO_LAYER_PATH}"

--- a/layers/layer1_python3_core/0000_adm/freeze_requirements
+++ b/layers/layer1_python3_core/0000_adm/freeze_requirements
@@ -48,10 +48,10 @@ if test "${N}" -eq 0; then
 fi
 
 # shellcheck disable=SC2086
-pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --disable-pip-version-check --src=./tmp_src --prefix="${TEMPO_LAYER_PATH}" -r "${REQUIREMENTS}" ${CONSTRAINT} >&2
+pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host downloads.sourceforge.net --disable-pip-version-check --src=./tmp_src --prefix="${TEMPO_LAYER_PATH}" -r "${REQUIREMENTS}" ${CONSTRAINT} >&2
 PYTHONPATH=$(echo "${PYTHONPATH}" |awk -F ":" '{print $1;}')
 export PYTHONPATH
-pip freeze --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --disable-pip-version-check -l |grep -v "^appdirs==" |grep -v "^packaging==" |grep -v "^pyparsing==" |grep -v "^six==" |grep -v "^virtualenv==" >${FREEZED_REQUIREMENTS}
+pip freeze --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host downloads.sourceforge.net --disable-pip-version-check -l |grep -v "^appdirs==" |grep -v "^packaging==" |grep -v "^pyparsing==" |grep -v "^six==" |grep -v "^virtualenv==" >${FREEZED_REQUIREMENTS}
 rm -Rf tmp_src src
 
 cat "${FREEZED_REQUIREMENTS}"

--- a/layers/layer1_python3_core/0000_adm/install_requirements
+++ b/layers/layer1_python3_core/0000_adm/install_requirements
@@ -34,7 +34,7 @@ else
     export HTTP_PROXY=http://127.0.0.1:9999
     export HTTPS_PROXY=http://127.0.0.1:9999
     export FORCED_INDEX_DIR_STRING="--no-cache-dir --no-index --find-links=$3"
-    cat "${REQUIREMENTS}" |sed 's/^-e git.*egg=\(.*\)$/\1/g' >"${REQUIREMENTS}.tmp"
+    cat "${REQUIREMENTS}" |sed 's/^-e git.*egg=\(.*\)$/\1/g' |sed 's/^https.*egg=\(.*\)$/\1/g' >"${REQUIREMENTS}.tmp"
 fi
 
 
@@ -66,6 +66,6 @@ if test "${N}" -eq 0; then
 fi
 
 # shellcheck disable=SC2086
-pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --disable-pip-version-check --src="${PREFIX_PATH}/lib/python${PYTHON_SHORT_VERSION}/src" --prefix="${LAYER_PATH}" -r "${REQUIREMENTS}.tmp" ${CONSTRAINT} ${FORCED_INDEX_DIR_STRING}
+pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --trusted-host downloads.sourceforge.net --disable-pip-version-check --src="${PREFIX_PATH}/lib/python${PYTHON_SHORT_VERSION}/src" --prefix="${LAYER_PATH}" -r "${REQUIREMENTS}.tmp" ${CONSTRAINT} ${FORCED_INDEX_DIR_STRING}
 rm -f "${REQUIREMENTS}.tmp"
 rm -Rf "${LAYER_PATH}/tmp/install_requirements"


### PR DESCRIPTION
The requirement must be of the following form :
https://url#egg=package
Example for basemap which has no link in pypi (see https://pypi.org/simple/basemap/)
https://downloads.sourceforge.net/project/matplotlib/matplotlib-toolkits/basemap-1.0.7/basemap-1.0.7.tar.gz#egg=basemap

Add https://downloads.sourceforge.net as trusted-host for pip