### PR TITLE
build: move circus_autorestart_plugin to mfext

### DIFF
--- a/layers/layer2_python3_circus/0500_circus/requirements-to-freeze.txt
+++ b/layers/layer2_python3_circus/0500_circus/requirements-to-freeze.txt
@@ -1,3 +1,4 @@
 #pyzmq<17 (move to layer python3)
 -e git+https://github.com/thefab/circus.git@metwork#egg=circus
 tornado==4.5.2
+-e git+https://github.com/metwork-framework/circus_autorestart_plugin.git#egg=circus_autorestart_plugin


### PR DESCRIPTION
Linked to metwork-framework/mfadmin#46