### PR TITLE
[WIP] feat: Simplify _metwork.spec with self discovery of layer dependencies

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -182,4 +182,4 @@ matrix:
     - centos6
     - centos7
 
-branches: [ master, integration, ci_*, pci_*, release_* ]
+branches: [ master, integration, experimental*, ci_*, pci_*, release_* ]

--- a/adm/main_root.mk
+++ b/adm/main_root.mk
@@ -13,7 +13,7 @@ ifeq ($(MODULE_HAS_HOME_DIR),)
     export MODULE_HAS_HOME_DIR=0
 endif
 ifeq ($(EPOCH),)
-    export EPOCH=5
+    export EPOCH=6
 endif
 ARCHIV=$(MODULE_LOWERCASE)-$(VERSION_BUILD)-$(RELEASE_BUILD)
 
@@ -135,4 +135,4 @@ rpm: archive
 	ln -s $(MODULE_HOME)/$(ARCHIV)-linux64.tar $(MODULE_HOME)/rpm/SOURCES/$(ARCHIV)-linux64.tar
 	cd $(MODULE_HOME)/rpm/SPECS && export HOME=$(MODULE_HOME)/rpm && rpmbuild -bb metwork-$(MODULE_LOWERCASE).spec
 	cp -f $(MODULE_HOME)/rpm/RPMS/x86_64/*.rpm $(MODULE_HOME)/
-	rm -Rf $(MODULE_HOME)/rpm
+	if test ! "$(DRONE)" = true; then rm -Rf $(MODULE_HOME)/rpm; fi

--- a/adm2/templates/profile
+++ b/adm2/templates/profile
@@ -124,10 +124,10 @@ field_prepend METWORK_LAYERS_PATH {{MFEXT_HOME}}/opt
 export METWORK_LAYERS_PATH
 
 # We load the default layer (if installed)
-N=$({{MFEXT_HOME}}/bin/is_layer_installed default 2>/dev/null)
+N=$({{MFEXT_HOME}}/bin/is_layer_installed default@${MODULE_LOWERCASE} 2>/dev/null)
 if test "${N}" = "1"; then
     # We load the default layer
-    layer_load default >/dev/null
+    layer_load default@${MODULE_LOWERCASE} >/dev/null
 else
     # The default layer is not installed
     # => we load the root and core layer (failback for developpers)

--- a/layers/layer9_default/.layerapi2_dependencies
+++ b/layers/layer9_default/.layerapi2_dependencies
@@ -1,10 +1,6 @@
 root@mfext
 core@mfext
 -devtools@mfext
--root@mfcom
--core@mfcom
--root@{MODULE_LOWERCASE}
--core@{MODULE_LOWERCASE}
 -mapserver@mfext
-python
+python@mfext
 -monitoring@mfext

--- a/layers/layer9_default/.layerapi2_label
+++ b/layers/layer9_default/.layerapi2_label
@@ -1,1 +1,1 @@
-default
+default@mfext

--- a/layers/layer9_python/.layerapi2_dependencies
+++ b/layers/layer9_python/.layerapi2_dependencies
@@ -2,5 +2,3 @@ python{METWORK_PYTHON_MODE}@mfext
 -python{METWORK_PYTHON_MODE}_scientific@mfext
 -python{METWORK_PYTHON_MODE}_devtools@mfext
 -python{METWORK_PYTHON_MODE}_devtools_jupyter@mfext
--python{METWORK_PYTHON_MODE}@mfcom
--python{METWORK_PYTHON_MODE}@{MODULE_LOWERCASE}

--- a/layers/layer9_python/.layerapi2_label
+++ b/layers/layer9_python/.layerapi2_label
@@ -1,1 +1,1 @@
-python
+python@mfext

--- a/wrappers/Makefile
+++ b/wrappers/Makefile
@@ -18,7 +18,7 @@ $(MFEXT_HOME)/bin/python3: custom_wrapper.c make_custom_wrapper.sh
 	./make_custom_wrapper.sh python3_core@mfext,-python3@mfext,-python3@mfcom,-python3@{MODULE_LOWERCASE} python $@
 
 $(MFEXT_HOME)/bin/python: custom_wrapper.c make_custom_wrapper.sh
-	./make_custom_wrapper.sh python python $@
+	./make_custom_wrapper.sh python@mfext,-python@mfcom,-python@{MODULE_LOWERCASE} python $@
 
 $(MFEXT_HOME)/bin/sphinx_wrapper: custom_wrapper.c make_custom_wrapper.sh
 	./make_custom_wrapper.sh python3_devtools@mfext sphinx-build $@

--- a/wrappers/flake82.sh
+++ b/wrappers/flake82.sh
@@ -8,4 +8,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=2
-layer_wrapper --layers=python -- flake8 --ignore D101,D102,D103,D100,D104,D401,D413,D107,D200,D204,D210,D400,D105 "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- flake8 --ignore D101,D102,D103,D100,D104,D401,D413,D107,D200,D204,D210,D400,D105 "$@"

--- a/wrappers/flake83.sh
+++ b/wrappers/flake83.sh
@@ -8,4 +8,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=3
-layer_wrapper --layers=python -- flake8 --ignore D101,D102,D103,D100,D104,D401,D413,D107,D200,D204,D210,D400,D105 "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- flake8 --ignore D101,D102,D103,D100,D104,D401,D413,D107,D200,D204,D210,D400,D105 "$@"

--- a/wrappers/nosetests2.sh
+++ b/wrappers/nosetests2.sh
@@ -7,4 +7,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=2
-layer_wrapper --layers=python -- nosetests "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- nosetests "$@"

--- a/wrappers/nosetests3.sh
+++ b/wrappers/nosetests3.sh
@@ -7,4 +7,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=3
-layer_wrapper --layers=python -- nosetests "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- nosetests "$@"

--- a/wrappers/pylint2.sh
+++ b/wrappers/pylint2.sh
@@ -7,4 +7,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=2
-layer_wrapper --layers=python -- pylint "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- pylint "$@"

--- a/wrappers/pylint3.sh
+++ b/wrappers/pylint3.sh
@@ -7,4 +7,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=3
-layer_wrapper --layers=python -- pylint "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- pylint "$@"


### PR DESCRIPTION
and management of metapackage names (keep only scientific and devtools and add minimal and full)
Associated with other changes in all modules, this reduces the number of layers installed by default when installing a module (only necessary mfext layers are installed)

mfext part of issue #26 (resources)
