### PR TITLE
[WIP] feat: Simplify _metwork.spec with self discovery of layer dependencies

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -182,4 +182,4 @@ matrix:
     - centos6
     - centos7
 
-branches: [ master, integration, ci_*, pci_*, release_* ]
+branches: [ master, integration, experimental*, ci_*, pci_*, release_* ]

--- a/adm/main_root.mk
+++ b/adm/main_root.mk
@@ -13,7 +13,7 @@ ifeq ($(MODULE_HAS_HOME_DIR),)
     export MODULE_HAS_HOME_DIR=0
 endif
 ifeq ($(EPOCH),)
-    export EPOCH=5
+    export EPOCH=6
 endif
 ARCHIV=$(MODULE_LOWERCASE)-$(VERSION_BUILD)-$(RELEASE_BUILD)
 
@@ -135,4 +135,4 @@ rpm: archive
 	ln -s $(MODULE_HOME)/$(ARCHIV)-linux64.tar $(MODULE_HOME)/rpm/SOURCES/$(ARCHIV)-linux64.tar
 	cd $(MODULE_HOME)/rpm/SPECS && export HOME=$(MODULE_HOME)/rpm && rpmbuild -bb metwork-$(MODULE_LOWERCASE).spec
 	cp -f $(MODULE_HOME)/rpm/RPMS/x86_64/*.rpm $(MODULE_HOME)/
-	rm -Rf $(MODULE_HOME)/rpm
+	if test ! "$(DRONE)" = true; then rm -Rf $(MODULE_HOME)/rpm; fi

--- a/adm2/_metwork.spec
+++ b/adm2/_metwork.spec
@@ -29,7 +29,7 @@
 {% set liste = 'cd $MODULE_HOME; ls -da bin config lib include share .layerapi2* 2>/dev/null'|shell -%}
 {% set root_list = liste.split('\n')[:-1] -%}
 {% set liste2 = 'if test -d $MODULE_HOME/opt; then cd $MODULE_HOME/opt; ls -d *; fi'|shell -%}
-{% set layers_list = liste2.split('\n')[:-1] -%}
+{% set full_layers_list = liste2.split('\n')[:-1] -%}
 
 Name: metwork-{{MODULE_LOWERCASE}}
 Summary: metwork {{MODULE_LOWERCASE}} module
@@ -46,29 +46,60 @@ Vendor: Metwork
 ExclusiveOs: linux
 AutoReq: no
 AutoProv: no
-Obsoletes: metwork-{{MODULE_LOWERCASE}}-full
-{% if MODULE == "MFEXT" -%}
-Requires: metwork-mfext-core-{{MFEXT_BRANCH}} = {{FULL_VERSION}}, metwork-mfext-python2-{{MFEXT_BRANCH}} = {{FULL_VERSION}}, metwork-mfext-devtools-{{MFEXT_BRANCH}} = {{FULL_VERSION}}, metwork-mfext-python2-devtools-{{MFEXT_BRANCH}} = {{FULL_VERSION}}, metwork-mfext-scientific-{{MFEXT_BRANCH}} = {{FULL_VERSION}}, metwork-mfext-python2-scientific-{{MFEXT_BRANCH}} = {{FULL_VERSION}}, metwork-mfext-nodejs-{{MFEXT_BRANCH}} = {{FULL_VERSION}}, metwork-mfext-mapserver-{{MFEXT_BRANCH}} = {{FULL_VERSION}}, metwork-mfext-monitoring-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
-{% else -%}
-Requires: metwork-mfext
-{% if MODULE == "MFCOM" -%}
-Requires: metwork-mfcom-core-{{MFCOM_BRANCH}} = {{FULL_VERSION}}, metwork-mfcom-python2-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
-{% else -%}
-Requires: metwork-mfcom
-{% if MODULE == "MFDATA" -%}
-Requires: metwork-mfdata-core-{{MODULE_BRANCH}} = {{FULL_VERSION}}, metwork-mfdata-python2-{{MODULE_BRANCH}} = {{FULL_VERSION}}
-{% else -%}
-{% if MODULE == "MFSERV" -%}
-Requires: metwork-mfserv-core-{{MODULE_BRANCH}} = {{FULL_VERSION}}, metwork-mfserv-python2-{{MODULE_BRANCH}} = {{FULL_VERSION}}, metwork-mfserv-nodejs-{{MODULE_BRANCH}}
-{% else -%}
-Requires: metwork-{{MODULE_LOWERCASE}}-core-{{MODULE_BRANCH}} = {{FULL_VERSION}}
-{% endif -%}
-{% endif -%}
-{% endif -%}
-{% endif -%}
-
+Requires: metwork-{{MODULE_LOWERCASE}}-layer-root-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
+{% for layer in full_layers_list -%}
+Requires: metwork-{{MODULE_LOWERCASE}}-layer-{{layer}}-{{MODULE_BRANCH}} = {{FULL_VERSION}}
+{% endfor -%}
 %description
 This package provides the full {{MODULE_LOWERCASE}} module of the metwork framework
+
+%package full
+Summary: metwork {{MODULE_LOWERCASE}} full module
+Group: Applications/Multimedia
+AutoReq: no
+AutoProv: no
+Requires: metwork-{{MODULE_LOWERCASE}} = {{FULL_VERSION}}
+%description full
+Alias for metwork-{{MODULE_LOWERCASE}}
+
+%package minimal
+Summary: metwork {{MODULE_LOWERCASE}} minimal module (default layer)
+Group: Applications/Multimedia
+AutoReq: no
+AutoProv: no
+Requires: metwork-{{MODULE_LOWERCASE}}-minimal-{{MODULE_BRANCH}} = {{FULL_VERSION}}
+%description minimal
+Minimal "individual layer" rpm list to install for module {{MODULE_LOWERCASE}}
+
+%package minimal-{{MODULE_BRANCH}}
+Summary: metwork {{MODULE_LOWERCASE}} minimal module (default layer) branch {{MODULE_BRANCH}}
+Group: Applications/Multimedia
+AutoReq: no
+AutoProv: no
+Requires: metwork-{{MODULE_LOWERCASE}}-layer-default-{{MODULE_BRANCH}} = {{FULL_VERSION}}
+# -e "s/^#+//" to add not loaded dependencies
+{% set cmd = 'cat ' + MODULE_HOME + '/opt/default' + '/.layerapi2_dependencies| grep -v "^-" | sed -e "s/{METWORK_PYTHON_MODE}/3/g" | sed -e "s/^#+//" | grep -v "{"' -%}
+{% set deps = cmd|shell -%}
+{% set deps_list = deps.split('\n')[:-1] -%}
+{% for d in deps_list -%}
+{% set layer_dep = d.split('@')[0] -%}
+{% set module_dep = (d+'@').split('@')[1] -%}
+{% if module_dep == "mfext" -%}
+{% set branch = MFEXT_BRANCH -%}
+{% elif module_dep == "mfcom" -%}
+{% set branch = MFCOM_BRANCH -%}
+{% else -%}
+{% set branch = MODULE_BRANCH -%}
+{% endif -%}
+{% if module_dep == MODULE_LOWERCASE -%}
+Requires: metwork-{{module_dep}}-layer-{{layer_dep}}-{{branch}} = {{FULL_VERSION}}
+{% else -%}
+# Do not specify version for layers out of the current module
+Requires: metwork-{{module_dep}}-layer-{{layer_dep}}-{{branch}}
+{% endif -%}
+{% endfor -%}
+%description minimal-{{MODULE_BRANCH}}
+Minimal rpm list to install for module {{MODULE_LOWERCASE}} + link /opt/metwork-{{MODULE_LOWERCASE}}
 
 %package layer-root-{{MODULE_BRANCH}}
 Summary: metwork {{MODULE_LOWERCASE}} root layer
@@ -89,17 +120,7 @@ Requires: openssl
 Requires: which
 Requires: /usr/bin/lscpu, /usr/bin/wget
 {% endif -%}
-%description layer-root-{{MODULE_BRANCH}}
-metwork {{MODULE_LOWERCASE}} root layer
-
-{% for layer in layers_list -%}
-%package layer-{{layer}}-{{MODULE_BRANCH}}
-Summary: metwork {{MODULE_LOWERCASE}} {{layer}} layer
-Group: Applications/Multimedia
-AutoReq: no
-AutoProv: no
-{% set liste = 'cd $MODULE_HOME; ls -da * .layerapi2*|grep -v opt'|shell -%}
-{% set cmd = 'cat ' + MODULE_HOME + '/opt/' + layer + '/.layerapi2_dependencies| grep -v "^-" | grep -v "{" | grep -v "^python$"' -%}
+{% set cmd = 'cat ' + MODULE_HOME + '/.layerapi2_dependencies| grep -v "^-" | sed -e "s/{METWORK_PYTHON_MODE}/3/g" | sed -e "s/^#+//" | grep -v "{"' -%}
 {% set deps = cmd|shell -%}
 {% set deps_list = deps.split('\n')[:-1] -%}
 {% for d in deps_list -%}
@@ -112,66 +133,50 @@ AutoProv: no
 {% else -%}
 {% set branch = MODULE_BRANCH -%}
 {% endif -%}
+{% if module_dep == MODULE_LOWERCASE -%}
+Requires: metwork-{{module_dep}}-layer-{{layer_dep}}-{{branch}} = {{FULL_VERSION}}
+{% else -%}
+# Do not specify version for layers out of the current module
 Requires: metwork-{{module_dep}}-layer-{{layer_dep}}-{{branch}}
+{% endif -%}
+{% endfor -%}
+%description layer-root-{{MODULE_BRANCH}}
+metwork {{MODULE_LOWERCASE}} root layer
+
+{% for layer in full_layers_list %}
+%package layer-{{layer}}-{{MODULE_BRANCH}}
+Summary: metwork {{MODULE_LOWERCASE}} {{layer}} layer
+Group: Applications/Multimedia
+AutoReq: no
+AutoProv: no
+# -e "s/^#+//" to add not loaded dependencies
+{% set cmd = 'cat ' + MODULE_HOME + '/opt/' + layer + '/.layerapi2_dependencies| grep -v "^-" | sed -e "s/{METWORK_PYTHON_MODE}/3/g" | sed -e "s/^#+//" | grep -v "{"' -%}
+{% set deps = cmd|shell -%}
+{% set deps_list = deps.split('\n')[:-1] -%}
+{% for d in deps_list -%}
+{% set layer_dep = d.split('@')[0] -%}
+{% set module_dep = (d+'@').split('@')[1] -%}
+{% if module_dep == "mfext" -%}
+{% set branch = MFEXT_BRANCH -%}
+{% elif module_dep == "mfcom" -%}
+{% set branch = MFCOM_BRANCH -%}
+{% else -%}
+{% set branch = MODULE_BRANCH -%}
+{% endif -%}
+{% if module_dep == MODULE_LOWERCASE -%}
+Requires: metwork-{{module_dep}}-layer-{{layer_dep}}-{{branch}} = {{FULL_VERSION}}
+{% else -%}
+# Do not specify version for layers out of the current module
+Requires: metwork-{{module_dep}}-layer-{{layer_dep}}-{{branch}}
+{% endif -%}
+{% if layer == "scientific" and MODULE_LOWERCASE == "mfext" -%}
+#Add "scientific" system dependencies (specified in meta layer scientific)
+Requires: metwork-mfext-scientific-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
+{% endif -%}
 {% endfor -%}
 %description layer-{{layer}}-{{MODULE_BRANCH}}
 metwork {{MODULE_LOWERCASE}} {{layer}} layer
 {% endfor -%}
-
-%package core-{{MODULE_BRANCH}}
-Summary: metwork {{MODULE_LOWERCASE}} meta core layers
-Group: Applications/Multimedia
-AutoReq: no
-AutoProv: no
-{% if MODULE == "MFEXT" -%}
-Requires: metwork-mfext-layer-root-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-core-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-default-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-python-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-openresty-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-python3-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-python3_core-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-python3_circus-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-rpm-{{MFEXT_BRANCH}}
-{% elif MODULE == "MFCOM" -%}
-Requires: metwork-mfext-core-{{MFEXT_BRANCH}}
-Requires: metwork-mfcom-layer-root-{{MFCOM_BRANCH}}
-Requires: metwork-mfcom-layer-python3-{{MFCOM_BRANCH}}
-{% elif MODULE == "MFDATA" or MODULE == "MFSERV" -%}
-Requires: metwork-mfcom-core-{{MFCOM_BRANCH}}
-Requires: metwork-{{MODULE_LOWERCASE}}-layer-root-{{MODULE_BRANCH}}
-Requires: metwork-{{MODULE_LOWERCASE}}-layer-python3-{{MODULE_BRANCH}}
-{% else -%}
-Requires: metwork-mfcom-core-{{MFCOM_BRANCH}}
-Requires: metwork-{{MODULE_LOWERCASE}}-layer-root-{{MODULE_BRANCH}}
-{% for layer in layers_list -%}
-Requires: metwork-{{MODULE_LOWERCASE}}-layer-{{layer}}-{{MODULE_BRANCH}}
-{% endfor -%}
-{% endif -%}
-%description core-{{MODULE_BRANCH}}
-metwork {{MODULE_LOWERCASE}} meta core layers
-
-{% if MODULE == "MFCOM" or MODULE == "MFDATA" or MODULE == "MFEXT" or MODULE == "MFSERV" -%}
-%package python2-{{MODULE_BRANCH}}
-Summary: metwork {{MODULE_LOWERCASE}} meta python2 layers
-Group: Applications/Multimedia
-AutoReq: no
-AutoProv: no
-Requires: metwork-{{MODULE_LOWERCASE}}-layer-python2-{{MODULE_BRANCH}}
-%description python2-{{MODULE_BRANCH}}
-metwork {{MODULE_LOWERCASE}} meta python2 layers
-{% endif -%}
-
-{% if MODULE == "MFSERV" -%}
-%package nodejs-{{MODULE_BRANCH}}
-Summary: metwork {{MODULE_LOWERCASE}} meta nodejs layers
-Group: Applications/Multimedia
-AutoReq: no
-AutoProv: no
-Requires: metwork-{{MODULE_LOWERCASE}}-layer-nodejs-{{MODULE_BRANCH}}
-%description nodejs-{{MODULE_BRANCH}}
-metwork {{MODULE_LOWERCASE}} meta nodejs layers
-{% endif -%}
 
 {% if MODULE == "MFEXT" -%}
 %package devtools-{{MFEXT_BRANCH}}
@@ -179,28 +184,28 @@ Summary: metwork {{MODULE_LOWERCASE}} meta devtools layers
 Group: Applications/Multimedia
 AutoReq: no
 AutoProv: no
-Requires: metwork-mfext-layer-devtools-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-python3_devtools-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-python3_devtools_jupyter-{{MFEXT_BRANCH}}
+Requires: metwork-mfext-layer-devtools-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
+Requires: metwork-mfext-layer-python3_devtools-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
+Requires: metwork-mfext-layer-python3_devtools_jupyter-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
 %description devtools-{{MFEXT_BRANCH}}
 metwork {{MODULE_LOWERCASE}} meta devtools layers
 
-%package python2-devtools-{{MFEXT_BRANCH}}
-Summary: metwork {{MODULE_LOWERCASE}} meta python2 devtools layers
+%package devtools
+Summary: metwork {{MODULE_LOWERCASE}} meta devtools layers
 Group: Applications/Multimedia
 AutoReq: no
 AutoProv: no
-Requires: metwork-mfext-layer-python2_devtools-{{MFEXT_BRANCH}}
-%description python2-devtools-{{MFEXT_BRANCH}}
-metwork {{MODULE_LOWERCASE}} meta python2 devtools layers
+Requires: metwork-mfext-devtools-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
+%description devtools
+Alias for metwork-mfext-devtools-{{MFEXT_BRANCH}} (without branch name)
 
 %package scientific-{{MFEXT_BRANCH}}
 Summary: metwork {{MODULE_LOWERCASE}} meta scientific layers
 Group: Applications/Multimedia
 AutoReq: no
 AutoProv: no
-Requires: metwork-mfext-layer-scientific-{{MFEXT_BRANCH}}
-Requires: metwork-mfext-layer-python3_scientific-{{MFEXT_BRANCH}}
+Requires: metwork-mfext-layer-scientific-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
+Requires: metwork-mfext-layer-python3_scientific-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
 Requires: libX11 libXext pango fontconfig freetype libgfortran libgomp libjpeg-turbo atlas libpng
 {% if METWORK_BUILD_OS|default('unknown') == "centos7" -%}
 Requires: libquadmath
@@ -208,50 +213,14 @@ Requires: libquadmath
 %description scientific-{{MFEXT_BRANCH}}
 metwork {{MODULE_LOWERCASE}} meta scientific layers
 
-%package nodejs-{{MFEXT_BRANCH}}
-Summary: metwork {{MODULE_LOWERCASE}} meta nodejs layers
+%package scientific
+Summary: metwork {{MODULE_LOWERCASE}} meta scientific layers
 Group: Applications/Multimedia
 AutoReq: no
 AutoProv: no
-Requires: metwork-mfext-layer-nodejs-{{MFEXT_BRANCH}}
-%description nodejs-{{MFEXT_BRANCH}}
-metwork {{MODULE_LOWERCASE}} meta nodejs layers
-
-%package java-{{MFEXT_BRANCH}}
-Summary: metwork {{MODULE_LOWERCASE}} meta java layers
-Group: Applications/Multimedia
-AutoReq: no
-AutoProv: no
-Requires: metwork-mfext-layer-java-{{MFEXT_BRANCH}}
-%description java-{{MFEXT_BRANCH}}
-metwork {{MODULE_LOWERCASE}} meta java layers
-
-%package mapserver-{{MFEXT_BRANCH}}
-Summary: metwork {{MODULE_LOWERCASE}} meta mapserver layers
-Group: Applications/Multimedia
-AutoReq: no
-AutoProv: no
-Requires: metwork-mfext-layer-mapserver-{{MFEXT_BRANCH}}
-%description mapserver-{{MFEXT_BRANCH}}
-metwork {{MODULE_LOWERCASE}} meta mapserver layers
-
-%package python2-scientific-{{MFEXT_BRANCH}}
-Summary: metwork {{MODULE_LOWERCASE}} meta python2 scientific layers
-Group: Applications/Multimedia
-AutoReq: no
-AutoProv: no
-Requires: metwork-mfext-layer-python2_scientific-{{MFEXT_BRANCH}}
-%description python2-scientific-{{MFEXT_BRANCH}}
-metwork {{MODULE_LOWERCASE}} meta python2 scientific layers
-
-%package monitoring-{{MFEXT_BRANCH}}
-Summary: metwork {{MODULE_LOWERCASE}} meta monitoring layers
-Group: Applications/Multimedia
-AutoReq: no
-AutoProv: no
-Requires: metwork-mfext-layer-monitoring-{{MFEXT_BRANCH}}
-%description monitoring-{{MFEXT_BRANCH}}
-metwork {{MODULE_LOWERCASE}} meta monitoring layers
+Requires: metwork-mfext-scientific-{{MFEXT_BRANCH}} = {{FULL_VERSION}}
+%description scientific
+Alias for metwork-mfext-scientific-{{MFEXT_BRANCH}} (without branch name)
 {% endif -%}
 
 %prep
@@ -378,8 +347,17 @@ rm -fr %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-# FIXME: try to avoid to hardcode /opt here
 {{TARGET_LINK}}
+
+%files full
+%defattr(-,root,root,-)
+
+%files minimal
+%defattr(-,root,root,-)
+{{TARGET_LINK}}
+
+%files minimal-{{MODULE_BRANCH}}
+%defattr(-,root,root,-)
 
 %files layer-root-{{MODULE_BRANCH}}
 %defattr(-,root,root,-)
@@ -394,47 +372,23 @@ rm -fr %{buildroot}
 /etc/security/limits.d/50-metwork.conf
 {% endif -%}
 
-{% for layer in layers_list -%}
+{% for layer in full_layers_list -%}
 %files layer-{{layer}}-{{MODULE_BRANCH}}
 %defattr(-,root,root,-)
 {{MODULE_HOME}}/opt/{{layer}}
-{% endfor -%}
 
-%files core-{{MFEXT_BRANCH}}
-%defattr(-,root,root,-)
+{% endfor -%}
 
 {% if MODULE == "MFEXT" -%}
 %files devtools-{{MFEXT_BRANCH}}
 %defattr(-,root,root,-)
 
-%files python2-devtools-{{MFEXT_BRANCH}}
+%files devtools
 %defattr(-,root,root,-)
 
 %files scientific-{{MFEXT_BRANCH}}
 %defattr(-,root,root,-)
 
-%files nodejs-{{MFEXT_BRANCH}}
-%defattr(-,root,root,-)
-
-%files mapserver-{{MFEXT_BRANCH}}
-%defattr(-,root,root,-)
-
-%files java-{{MFEXT_BRANCH}}
-%defattr(-,root,root,-)
-
-%files python2-scientific-{{MFEXT_BRANCH}}
-%defattr(-,root,root,-)
-
-%files monitoring-{{MFEXT_BRANCH}}
-%defattr(-,root,root,-)
-{% endif -%}
-
-{% if MODULE == "MFSERV" -%}
-%files nodejs-{{MODULE_BRANCH}}
-%defattr(-,root,root,-)
-{% endif -%}
-
-{% if MODULE == "MFEXT" or MODULE == "MFCOM" or MODULE == "MFDATA" or MODULE == "MFSERV" -%}
-%files python2-{{MODULE_BRANCH}}
+%files scientific
 %defattr(-,root,root,-)
 {% endif -%}

--- a/adm2/templates/profile
+++ b/adm2/templates/profile
@@ -124,10 +124,10 @@ field_prepend METWORK_LAYERS_PATH {{MFEXT_HOME}}/opt
 export METWORK_LAYERS_PATH
 
 # We load the default layer (if installed)
-N=$({{MFEXT_HOME}}/bin/is_layer_installed default 2>/dev/null)
+N=$({{MFEXT_HOME}}/bin/is_layer_installed default@${MODULE_LOWERCASE} 2>/dev/null)
 if test "${N}" = "1"; then
     # We load the default layer
-    layer_load default >/dev/null
+    layer_load default@${MODULE_LOWERCASE} >/dev/null
 else
     # The default layer is not installed
     # => we load the root and core layer (failback for developpers)

--- a/layers/layer9_default/.layerapi2_dependencies
+++ b/layers/layer9_default/.layerapi2_dependencies
@@ -1,10 +1,6 @@
 root@mfext
 core@mfext
 -devtools@mfext
--root@mfcom
--core@mfcom
--root@{MODULE_LOWERCASE}
--core@{MODULE_LOWERCASE}
 -mapserver@mfext
-python
+python@mfext
 -monitoring@mfext

--- a/layers/layer9_default/.layerapi2_label
+++ b/layers/layer9_default/.layerapi2_label
@@ -1,1 +1,1 @@
-default
+default@mfext

--- a/layers/layer9_python/.layerapi2_dependencies
+++ b/layers/layer9_python/.layerapi2_dependencies
@@ -2,5 +2,3 @@ python{METWORK_PYTHON_MODE}@mfext
 -python{METWORK_PYTHON_MODE}_scientific@mfext
 -python{METWORK_PYTHON_MODE}_devtools@mfext
 -python{METWORK_PYTHON_MODE}_devtools_jupyter@mfext
--python{METWORK_PYTHON_MODE}@mfcom
--python{METWORK_PYTHON_MODE}@{MODULE_LOWERCASE}

--- a/layers/layer9_python/.layerapi2_label
+++ b/layers/layer9_python/.layerapi2_label
@@ -1,1 +1,1 @@
-python
+python@mfext

--- a/wrappers/Makefile
+++ b/wrappers/Makefile
@@ -18,7 +18,7 @@ $(MFEXT_HOME)/bin/python3: custom_wrapper.c make_custom_wrapper.sh
 	./make_custom_wrapper.sh python3_core@mfext,-python3@mfext,-python3@mfcom,-python3@{MODULE_LOWERCASE} python $@
 
 $(MFEXT_HOME)/bin/python: custom_wrapper.c make_custom_wrapper.sh
-	./make_custom_wrapper.sh python python $@
+	./make_custom_wrapper.sh python@mfext,-python@mfcom,-python@{MODULE_LOWERCASE} python $@
 
 $(MFEXT_HOME)/bin/sphinx_wrapper: custom_wrapper.c make_custom_wrapper.sh
 	./make_custom_wrapper.sh python3_devtools@mfext sphinx-build $@

--- a/wrappers/flake82.sh
+++ b/wrappers/flake82.sh
@@ -8,4 +8,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=2
-layer_wrapper --layers=python -- flake8 --ignore D101,D102,D103,D100,D104,D401,D413,D107,D200,D204,D210,D400,D105 "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- flake8 --ignore D101,D102,D103,D100,D104,D401,D413,D107,D200,D204,D210,D400,D105 "$@"

--- a/wrappers/flake83.sh
+++ b/wrappers/flake83.sh
@@ -8,4 +8,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=3
-layer_wrapper --layers=python -- flake8 --ignore D101,D102,D103,D100,D104,D401,D413,D107,D200,D204,D210,D400,D105 "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- flake8 --ignore D101,D102,D103,D100,D104,D401,D413,D107,D200,D204,D210,D400,D105 "$@"

--- a/wrappers/nosetests2.sh
+++ b/wrappers/nosetests2.sh
@@ -7,4 +7,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=2
-layer_wrapper --layers=python -- nosetests "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- nosetests "$@"

--- a/wrappers/nosetests3.sh
+++ b/wrappers/nosetests3.sh
@@ -7,4 +7,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=3
-layer_wrapper --layers=python -- nosetests "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- nosetests "$@"

--- a/wrappers/pylint2.sh
+++ b/wrappers/pylint2.sh
@@ -7,4 +7,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=2
-layer_wrapper --layers=python -- pylint "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- pylint "$@"

--- a/wrappers/pylint3.sh
+++ b/wrappers/pylint3.sh
@@ -7,4 +7,4 @@ if test "${1:-}" == "--help"; then
     exit 0
 fi
 export METWORK_PYTHON_MODE=3
-layer_wrapper --layers=python -- pylint "$@"
+layer_wrapper --layers=python@mfext,-python@mfcom,-python@"${MODULE_LOWERCASE}" -- pylint "$@"


### PR DESCRIPTION
and management of metapackage names (keep only scientific and devtools and add minimal and full)
 Associated with other changes in all modules, this reduces the number of layers installed by default when installing a module (only necessary mfext layers are installed)

 mfext part of issue #26 (resources)