### PR TITLE
feat: user-defined configuration name

### DIFF
--- a/adm2/templates/profile
+++ b/adm2/templates/profile
@@ -61,9 +61,11 @@ fi
 {% endif %}
 
 # Get the metwork configuration name
-MFCONFIG=$(cat /etc/metwork.config 2>/dev/null |sed 's/ //g' |grep -v '^#' |head -1)
 if test "${MFCONFIG}" = ""; then
-    MFCONFIG=GENERIC
+    MFCONFIG=$(cat /etc/metwork.config 2>/dev/null |sed 's/ //g' |grep -v '^#' |head -1)
+    if test "${MFCONFIG}" = ""; then
+        MFCONFIG=GENERIC
+    fi
 fi
 export MFCONFIG
 

--- a/adm2/templates/profile
+++ b/adm2/templates/profile
@@ -61,7 +61,7 @@ fi
 {% endif %}
 
 # Get the metwork configuration name
-if test "${MFCONFIG}" = ""; then
+if test "${MFCONFIG:-}" = ""; then
     MFCONFIG=$(cat /etc/metwork.config 2>/dev/null |sed 's/ //g' |grep -v '^#' |head -1)
     if test "${MFCONFIG}" = ""; then
         MFCONFIG=GENERIC


### PR DESCRIPTION
Add the possibility to define a configuration name at the user level. When defined at this level (for example with "export MFCONFIG=myconfig" in ~username/.bashrc), this configuration name is used instead of the one defined in /etc/metwork.config or the default one.