### PR TITLE
fix: disable SSE4.2 optimizations to avoid nginx crashing on old servers

### DIFF
--- a/layers/layer1_openresty/0100_openresty/github_issue384.patch
+++ b/layers/layer1_openresty/0100_openresty/github_issue384.patch
@@ -1,0 +1,58 @@
+diff -up openresty-1.13.6.2/configure.metwork openresty-1.13.6.2/configure
+--- openresty-1.13.6.2/configure.metwork	2019-06-24 15:11:35.530461763 +0200
++++ openresty-1.13.6.2/configure	2019-06-24 15:14:08.120500732 +0200
+@@ -652,50 +652,11 @@ _END_
+             $luajit_xcflags .= " -DLUAJIT_ENABLE_LUA52COMPAT";
+         }
+ 
+-        if (!$user_luajit_xcflags
+-            || $user_luajit_xcflags !~ /-msse4\.2\b/)
+-        {
+-            # check -msse4.2
+-            my ($out, $cfile) = tempfile("resty-config-XXXXXX",
+-                                         SUFFIX => '.c', TMPDIR => 1,
+-                                         UNLINK => 1);
+-
+-            print $out "
+-int main(void) {
+-#ifndef __SSE4_2__
+-#   error SSE 4.2 not found
+-#endif
+-    return 0;
+-}
+-";
+-            close $out;
+-
+-            my $ofile = tmpnam();
+-            my $comp = ($cc || 'cc');
+-            my $found;
+-
+-            if (system("$comp -o $ofile -msse4.2 -c $cfile") == 0
+-                && -s $ofile)
+-            {
+-                unlink $ofile;
+-
+-                if (system("$comp -o $ofile -march=native -c $cfile") == 0
+-                    && -s $ofile)
+-                {
+-                    print "INFO: found -msse4.2 in $comp.\n";
+-                    $found = 1;
+-                    $luajit_xcflags .= " -msse4.2";
+-                }
+-            }
+-
+-            if (-f $ofile) {
+-                unlink $ofile;
+-            }
++        # We don't want to use sse42 optimisations
++        # for the moment
++        # see https://github.com/openresty/openresty/issues/267
++        # https://github.com/metwork-framework/mfext/issues/384
+ 
+-            if (!$found) {
+-                print "WARNING: -msse4.2 not supported in $comp.\n";
+-            }
+-        }
+ 
+         if ($opts->{debug}) {
+             $luajit_xcflags .= " -DLUA_USE_APICHECK -DLUA_USE_ASSERT";

--- a/layers/layer1_openresty/0100_openresty/patches
+++ b/layers/layer1_openresty/0100_openresty/patches
@@ -1,1 +1,2 @@
 github_pr67.patch
+github_issue384.patch


### PR DESCRIPTION
Close: #384