### PR TITLE
fix: fix metwork services start for systems where /sys is readonly

### DIFF
--- a/layers/layer9_misc/0000_adm/metwork
+++ b/layers/layer9_misc/0000_adm/metwork
@@ -125,7 +125,7 @@ fix_system() {
     if ! test -f "/etc/metwork.config.d/system/no_sysctl"; then
       (echo never > /sys/kernel/mm/transparent_hugepage/enabled) 2>/dev/null
       if test $? -eq 0; then      
-        echo -n "System: disabling transparent_hugepage...  Ok"
+        echo "System: disabling transparent_hugepage...  Ok"
       else
         N=$(grep -c "^never$" /sys/kernel/mm/transparent_hugepage/enabled)
         if test ${N} -eq 0; then

--- a/layers/layer9_misc/0000_adm/metwork
+++ b/layers/layer9_misc/0000_adm/metwork
@@ -123,12 +123,14 @@ fix_system() {
   fi
   if test -f /sys/kernel/mm/transparent_hugepage/enabled; then
     if ! test -f "/etc/metwork.config.d/system/no_sysctl"; then
-      echo -n "System: disabling transparent_hugepage... "
-      echo never > /sys/kernel/mm/transparent_hugepage/enabled
-      if test $? -eq 0; then
-        echo "Ok"
+      (echo never > /sys/kernel/mm/transparent_hugepage/enabled) 2>/dev/null
+      if test $? -eq 0; then      
+        echo -n "System: disabling transparent_hugepage...  Ok"
       else
-        echo "ERROR"
+        N=$(grep -c "^never$" /sys/kernel/mm/transparent_hugepage/enabled)
+        if test ${N} -eq 0; then
+          echo "System: can't disable transparent_hugepage (WARNING)"
+        fi
       fi
     fi
   fi


### PR DESCRIPTION
Close: https://github.com/metwork-framework/resources/issues/45