### PR TITLE
fix: mfserv_wrapper now loads custom metwork profiles

### DIFF
--- a/adm/templates/_mfxxx_wrapper
+++ b/adm/templates/_mfxxx_wrapper
@@ -5,11 +5,22 @@ if test "${1:-}" = ""; then
     exit 1
 fi
 
+# We eventually override with system wide custom settings
+if test -f /etc/metwork.custom_profile; then
+    # shellcheck disable=SC1091
+    . /etc/metwork.custom_profile
+fi
+
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if test "${METWORK_PROFILE_LOADED}" != "1" -a "${METWORK_PROFILE_LOADING}" != "1"; then
     if test -f "${CURRENT_DIR}/../share/profile"; then
         . "${CURRENT_DIR}/../share/profile"
     fi
+fi
+
+# We eventually override with module wide custom settings
+if test -f ~/.metwork.custom_profile; then
+    . ~/.metwork.custom_profile
 fi
 
 exec "$@"


### PR DESCRIPTION
mfserv_wrapper now loads custom metwork profiles like with
bashrc/bash_profile

Close: #560