### PR TITLE
feat: upgrade proj from 5.2.0 to 6.2.1 with patch to accept use of de…

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -161,7 +161,7 @@
 | [postgis](http://postgis.refractions.net/) | 2.4.6 | scientific_core |
 | [postgresql](http://postgresql.org/) | 10.11 | scientific_core |
 | [poyo](https://github.com/hackebrot/poyo) | 0.4.2 | python3 |
-| [proj](http://trac.osgeo.org/proj/) | 5.2.0 | scientific_core |
+| [proj](http://trac.osgeo.org/proj/) | 6.2.1 | scientific_core |
 | [psutil](https://github.com/giampaolo/psutil) | 5.6.3 | python2 |
 | [psutil](https://github.com/giampaolo/psutil) | 5.6.3 | python3 |
 | [py](http://py.readthedocs.io/) | 1.8.0 | python2_devtools |

--- a/layers/layer1_scientific_core/0020_proj4/Makefile.mk
+++ b/layers/layer1_scientific_core/0020_proj4/Makefile.mk
@@ -7,19 +7,17 @@ include ../../package.mk
 #will be released in cartopy
 
 export NAME=proj
-export VERSION=5.2.0
-#export VERSION=6.1.0
+export VERSION=6.2.1
 export EXTENSION=tar.gz
 export CHECKTYPE=MD5
-export CHECKSUM=ad285c7d03cbb138d9246e10e1f3191c
-#export CHECKSUM=4ec5d9240b0e290670886519f250946c (6.1.0)
+export CHECKSUM=9f874e227d221daf95f7858dc55dfa3e
 DESCRIPTION=\
 PROJ4 is a generic coordinate transformation software that transforms geospatial coordinates \
 from one coordinate reference system (CRS) to another.
 WEBSITE=http://trac.osgeo.org/proj/
 LICENSE=MIT
 
-# proj 5.2.0 or 6.1.0 needs C++11 to build (not natively available on CentOS6).
+# proj > 5.2.0 needs C++11 to build (not natively available on CentOS6).
 # So we build it with temporary scl if gcc < 4.8
 GCC_VERSION = `gcc --version | head -1 | cut -d" " -f3 | cut -d"." -f1-2`
 DEVTOOLSET = 7

--- a/layers/layer1_scientific_core/0020_proj4/accept_use_of_deprecated_proj_api_h.patch
+++ b/layers/layer1_scientific_core/0020_proj4/accept_use_of_deprecated_proj_api_h.patch
@@ -1,0 +1,16 @@
+diff -up proj-6.2.1/src/proj_api.h.orig proj-6.2.1/src/proj_api.h
+--- proj-6.2.1/src/proj_api.h.orig	2019-12-03 16:05:18.508938972 +0100
++++ proj-6.2.1/src/proj_api.h	2019-12-03 16:05:03.193938985 +0100
+@@ -33,9 +33,12 @@
+   *
+   */
+ 
++/* We allow use of this deprecated file in Metwork because of libspatialite and cartopy */
++/*
+ #ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+ #error 'To use the proj_api.h you must define the macro ACCEPT_USE_OF_DEPRECATED_PROJ_API_H'
+ #endif
++*/
+ 
+ #ifndef PJ_VERSION
+ #define PJ_VERSION 621

--- a/layers/layer1_scientific_core/0020_proj4/patches
+++ b/layers/layer1_scientific_core/0020_proj4/patches
@@ -1,3 +1,5 @@
+#Accept use of deprecated proj_api.h
+accept_use_of_deprecated_proj_api_h.patch
 #Support projection Skew Mercator AERO
 #patch 4.8 to port in 6.1
 #proj4-skewmercator.patch

--- a/layers/layer1_scientific_core/0020_proj4/sources
+++ b/layers/layer1_scientific_core/0020_proj4/sources
@@ -1,2 +1,1 @@
-https://download.osgeo.org/proj/proj-5.2.0.tar.gz
-#https://download.osgeo.org/proj/proj-6.1.0.tar.gz
+https://download.osgeo.org/proj/proj-6.2.1.tar.gz


### PR DESCRIPTION
…precated proj_api.h

(some other packages such as spatialite and cartopy are still using proj_api.h instead of proj.h)