### PR TITLE
build: add pathlib, missing dependency of gitignore-parser in python2

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -159,6 +159,7 @@
 | [opinionated-configparser](https://github.com/metwork-framework/opinionated_configparser) | custom | python3 |
 | [packaging](https://github.com/pypa/packaging) | 19.0 | python2_core |
 | [packaging](https://github.com/pypa/packaging) | 19.0 | python3_core |
+| [pathlib](https://pathlib.readthedocs.org/) | 1.0.1 | python2 |
 | [pathlib2](https://github.com/mcmtroffaes/pathlib2) | 2.3.5 | python2_devtools |
 | [pathspec](https://github.com/cpburnz/python-path-specification) | 0.7.0 | python3_devtools |
 | [pcre](http://www.pcre.org) | 8.43 | core |
@@ -278,4 +279,4 @@
 | [zipp](https://github.com/jaraco/zipp) | 0.6.0 | python2_devtools |
 | [zipp](https://github.com/jaraco/zipp) | 0.6.0 | python3_devtools |
 
-*(277 components)*
+*(278 components)*

--- a/layers/layer2_python2/0500_extra_python_packages/requirements-to-freeze.txt
+++ b/layers/layer2_python2/0500_extra_python_packages/requirements-to-freeze.txt
@@ -22,3 +22,4 @@ diskcache
 terminaltables
 PyYAML
 unidecode
+pathlib

--- a/layers/layer2_python2/0500_extra_python_packages/requirements2.txt
+++ b/layers/layer2_python2/0500_extra_python_packages/requirements2.txt
@@ -19,6 +19,7 @@ MarkupSafe==1.1.1
 -e git+https://github.com/metwork-framework/mflog.git@40802be13aa14b3c94518fcc90295ac88997a1e5#egg=mflog
 -e git+https://github.com/metwork-framework/mfutil.git@bc2fc42f9a5e903bc054bd13ccbd23a6bfb31793#egg=mfutil
 netifaces==0.10.9
+pathlib==1.0.1
 psutil==5.6.3
 PyYAML==5.1.2
 redis==3.2.1


### PR DESCRIPTION
This will fix an error in integration tests for mfserv