### PR TITLE
fix: fix systemctl startup with some circusctl versions

### DIFF
--- a/layers/layer9_misc/0000_adm/metwork.service
+++ b/layers/layer9_misc/0000_adm/metwork.service
@@ -8,8 +8,8 @@ RemainAfterExit=true
 ExecStop=/etc/rc.d/init.d/metwork stop
 LimitNOFILE=65536
 LimitNPROC=100000
-TimeoutStartSec=infinity
-TimeoutStopSec=infinity
+TimeoutStartSec=3600
+TimeoutStopSec=3600
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Amazon Linux 2 in particular