### PR TITLE
fix: give up profile loading when a required layer is missing (with a…

### DIFF
--- a/adm/templates/profile
+++ b/adm/templates/profile
@@ -122,19 +122,17 @@ if test "${N}" = "1"; then
     # note: if we are in a plugin_env, we don't load default layers (issue mfserv#220)
     if test "{% raw %}${{% endraw %}{{MFMODULE}}_CURRENT_PLUGIN_NAME:-}" = ""; then
         # We load the default layer
-        layer_load default@${MFMODULE_LOWERCASE} >/tmp/message$$ 2>&1
-        message=$( cat /tmp/message$$ | grep INFO )
-        N=$({{MFEXT_HOME}}/opt/core/bin/is_layer_loaded default@${MFMODULE_LOWERCASE} 2>/dev/null)
+        layer_load default@${MFMODULE_LOWERCASE} >"/tmp/layer_load_${MFMODULE_LOWERCASE}_$$" 2>&1
+        N=$("{{MFEXT_HOME}}/opt/core/bin/is_layer_loaded" default@${MFMODULE_LOWERCASE} 2>/dev/null)
         if test "${N}" != "1"; then
             ${MFEXT_HOME}/opt/core/bin/echo_bold "[ERROR]: Can't load layer default@${MFMODULE_LOWERCASE}"
             ${MFEXT_HOME}/opt/core/bin/echo_bold "[INFO]: One of the required dependency layers is probably not installed ==> so no layer at all has been loaded"
-            ${MFEXT_HOME}/opt/core/bin/echo_bold "${message}"
+            ${MFEXT_HOME}/opt/core/bin/echo_bold "=> see /tmp/layer_load_${MFMODULE_LOWERCASE}_$$ for details"
             export PROFILE_ERROR=1
             unset METWORK_PROFILE_LOADING
-            rm /tmp/message$$
             return 1
         fi
-        rm /tmp/message$$
+        rm "/tmp/layer_load_${MFMODULE_LOWERCASE}_$$"
     fi
 else
     # The default layer is not installed

--- a/adm/templates/profile
+++ b/adm/templates/profile
@@ -122,7 +122,19 @@ if test "${N}" = "1"; then
     # note: if we are in a plugin_env, we don't load default layers (issue mfserv#220)
     if test "{% raw %}${{% endraw %}{{MFMODULE}}_CURRENT_PLUGIN_NAME:-}" = ""; then
         # We load the default layer
-        layer_load default@${MFMODULE_LOWERCASE} >/dev/null
+        layer_load default@${MFMODULE_LOWERCASE} >/tmp/message$$ 2>&1
+        message=$( cat /tmp/message$$ | grep INFO )
+        N=$({{MFEXT_HOME}}/opt/core/bin/is_layer_loaded default@${MFMODULE_LOWERCASE} 2>/dev/null)
+        if test "${N}" != "1"; then
+            ${MFEXT_HOME}/opt/core/bin/echo_bold "[ERROR]: Can't load layer default@${MFMODULE_LOWERCASE}"
+            ${MFEXT_HOME}/opt/core/bin/echo_bold "[INFO]: One of the required dependency layers is probably not installed ==> so no layer at all has been loaded"
+            ${MFEXT_HOME}/opt/core/bin/echo_bold "${message}"
+            export PROFILE_ERROR=1
+            unset METWORK_PROFILE_LOADING
+            rm /tmp/message$$
+            return 1
+        fi
+        rm /tmp/message$$
     fi
 else
     # The default layer is not installed


### PR DESCRIPTION
…n explicit error message)