### PR TITLE
build: move Markdown and tqdm from python3_devtools to python3 (they …

### DIFF
--- a/layers/layer2_python3/0500_extra_python_packages/requirements-to-freeze.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements-to-freeze.txt
@@ -40,3 +40,5 @@ paramiko
 attrs
 wrapt
 zipp
+Markdown
+tqdm

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -27,10 +27,12 @@ filelock==3.0.12
 future==0.17.1
 gitignore-parser==0.0.6
 idna==2.8
+importlib-metadata==2.0.0
 inotify-simple==1.1.8
 Jinja2==2.10.1
 jinja2-time==0.2.0
 lazy-import==0.2.2
+Markdown==3.3.3
 MarkupSafe==1.1.1
 mflog==0.0.4
 -e git+https://github.com/metwork-framework/mfplugin.git@0cf569a70eb16b5e9ee3b3e07604d0216c6a16d6#egg=mfplugin
@@ -60,6 +62,7 @@ simpleeval==0.9.10
 structlog==19.1.0
 -e git+https://github.com/metwork-framework/telegraf-unixsocket-python-client@d41af1a6af7c796cd835c1a98c773989cdb0897e#egg=telegraf_unixsocket_client
 terminaltables==3.1.0
+tqdm==4.53.0
 typing-extensions==3.7.4.2
 Unidecode==1.1.1
 urllib3==1.25.3

--- a/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
@@ -7,14 +7,12 @@ execnet==1.7.1
 flake8==3.8.1
 flake8-docstrings==1.5.0
 freezegun==0.3.15
-importlib-metadata==1.6.0
 isort==4.3.21
 joblib==0.15.1
 lazy-object-proxy==1.4.3
 livereload==2.6.1
 lunr==0.5.8
 Mako==1.1.2
-Markdown==3.2.2
 mccabe==0.6.1
 mkdocs==1.1.2
 mkdocs-add-number-plugin==1.2.1
@@ -49,7 +47,6 @@ repackage==0.7.3
 snowballstemmer==2.0.0
 termcolor==1.1.0
 tornado==6.0.4
-tqdm==4.51.0
 typed-ast==1.4.1
 wcwidth==0.2.5
 Werkzeug==1.0.1


### PR DESCRIPTION
…are used in addon scientific)