### PR TITLE
feat: upgrade aiohttp from 3.6.3 to 3.7.4 to fix security vulnerability

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -2,7 +2,7 @@
 | --- | --- | --- |
 | [acquisition](https://github.com/metwork-framework/acquisition) | custom | python3 |
 | [aiohttp-metwork-middlewares](https://github.com/metwork-framework/aiohttp_metwork_middlewares) | custom | python3 |
-| [aiohttp](https://github.com/aio-libs/aiohttp) | 3.6.3 | python3 |
+| [aiohttp](https://github.com/aio-libs/aiohttp) | 3.7.4 | python3 |
 | [apipkg](https://github.com/pytest-dev/apipkg) | 1.5 | python3_devtools |
 | [appdirs](http://github.com/ActiveState/appdirs) | 1.4.3 | python3_core |
 | [arrow](https://arrow.readthedocs.io/en/latest/) | 0.14.2 | python3 |
@@ -210,7 +210,7 @@
 | [xattrfile](https://github.com/metwork-framework/xattrfile) | custom | python3 |
 | [xz](https://tukaani.org/xz/) | 5.2.5 | core |
 | [yajl](https://lloyd.github.io/yajl/) | 2.1.0 | core |
-| [yarl](https://github.com/aio-libs/yarl/) | 1.5.1 | python3 |
+| [yarl](https://github.com/aio-libs/yarl/) | 1.6.3 | python3 |
 | [zipp](https://github.com/jaraco/zipp) | 3.4.0 | python3 |
 
 *(212 components)*

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/metwork-framework/acquisition.git@af2fabc0c84c79ba6e9f9f83fa06d994d4e974df#egg=acquisition
-aiohttp==3.6.3
+aiohttp==3.7.4
 -e git+https://github.com/metwork-framework/aiohttp_metwork_middlewares.git@6ec9424f24b7b89298dfcabde36ad49332cbecc4#egg=aiohttp_metwork_middlewares
 arrow==0.14.2
 async-timeout==3.0.1
@@ -69,7 +69,7 @@ urllib3==1.25.3
 whichcraft==0.5.2
 wrapt==1.12.1
 -e git+https://github.com/metwork-framework/xattrfile.git@9c0b2974deeafed59caa3659c685a89e686a0159#egg=xattrfile
-yarl==1.5.1
+yarl==1.6.3
 zipp==3.4.0
 -e git+https://github.com/metwork-framework/jinja2_fnmatch_extension@014bee0ebdaca0e3dc96a2e322db1b5dd6f0e1a2#egg=jinja2_fnmatch_extension
 -e git+https://github.com/metwork-framework/jinja2_from_json_extension@4b1bf5e9408003dd858f6d8e1346d61b4075f1a3#egg=jinja2_from_json_extension


### PR DESCRIPTION
https://github.com/advisories/GHSA-v6wp-4m6f-gcjg
and upgrade yarl from 1.5.1 to 1.6.3 (yarl had been downgraded with aiohttp 3.6.3)