### PR TITLE
fix: json_file=AUTO is now the same than json_file=null

### DIFF
--- a/adm/templates/config.ini
+++ b/adm/templates/config.ini
@@ -48,8 +48,8 @@ minimal_level=INFO
 # monitoring tool)
 # If json_file value is :
 # null => the feature is desactivated
-# AUTO => the json_file is @@@MFMODULE_RUNTIME_HOME@@@/log/json_logs.log
-#         if [admin]/hostname != null else null (desactivated)
+# AUTO => the feature is desactivated (because it's not necessary anymore
+#         since 1.2 version)
 json_file=null
 
 # Minimal level for this json log file

--- a/adm/templates/profile
+++ b/adm/templates/profile
@@ -197,11 +197,7 @@ fi
 
 # A little kind of magic to deal with [log]/json_file=AUTO
 if test "{% raw %}${{% endraw %}{{MFMODULE}}_LOG_JSON_FILE{% raw %}:-}{% endraw %}" = "AUTO"; then
-    if test "{% raw %}${{% endraw %}{{MFMODULE}}_ADMIN_HOSTNAME{% raw %}:-}{% endraw %}" = "null"; then
-        export MFLOG_JSON_FILE="null"
-    else
-        export MFLOG_JSON_FILE="{% raw %}${MFMODULE_RUNTIME_HOME}{% endraw %}/log/json_logs.log"
-    fi
+    export MFLOG_JSON_FILE="null"
 fi
 
 if test "{% raw %}${{% endraw %}{{MFMODULE}}_LOG_NUMBER_OF_ROTATED_FILES{% raw %}:-}{% endraw %}" != ""; then


### PR DESCRIPTION
since 1.2 version, json_file feature is not used by metwork