### PR TITLE
build: revert : remove useless python3 dep (backport #1298) (#1299)

### DIFF
--- a/layers/layer8_monitoring/.layerapi2_dependencies
+++ b/layers/layer8_monitoring/.layerapi2_dependencies
@@ -1,1 +1,2 @@
 core@mfext
+python3@mfext


### PR DESCRIPTION
This reverts commit 704f54324dacbbed4b745cd82d03d6e03948badb.