### PR TITLE
fix: rename gdal's internal g2clib symbols to avoid conflicts

### DIFF
--- a/layers/layer1_scientific_core/0023_gdal/patches
+++ b/layers/layer1_scientific_core/0023_gdal/patches
@@ -1,0 +1,3 @@
+#Patch to rename internal g2clib symbols to avoid conflicts with ncl
+#from https://github.com/rouault/gdal/commit/94fde15830b77a0150dda5ed075bfd8da364879f
+rename_g2clib_symbols.patch

--- a/layers/layer1_scientific_core/0023_gdal/rename_g2clib_symbols.patch
+++ b/layers/layer1_scientific_core/0023_gdal/rename_g2clib_symbols.patch
@@ -1,0 +1,125 @@
+diff -up gdal-3.0.2/frmts/grib/degrib/g2clib/gdal_g2clib_symbol_rename.h.orig gdal-3.0.2/frmts/grib/degrib/g2clib/gdal_g2clib_symbol_rename.h
+--- gdal-3.0.2/frmts/grib/degrib/g2clib/gdal_g2clib_symbol_rename.h.orig	2022-04-07 13:25:31.469046022 +0000
++++ gdal-3.0.2/frmts/grib/degrib/g2clib/gdal_g2clib_symbol_rename.h	2022-04-07 13:34:05.592161484 +0000
+@@ -0,0 +1,66 @@
++/* This is a generated file by rename_g2clib_symbols.sh. *DO NOT EDIT MANUALLY !* */
++#define cmplxpack gdal_cmplxpack
++#define compack gdal_compack
++#define comunpack gdal_comunpack
++#define dec_png gdal_dec_png
++#define DoubleToFloatClamp gdal_DoubleToFloatClamp
++#define DoubleToFloatClamp gdal_DoubleToFloatClamp
++#define DoubleToFloatClamp gdal_DoubleToFloatClamp
++#define DoubleToFloatClamp gdal_DoubleToFloatClamp
++#define DoubleToFloatClamp gdal_DoubleToFloatClamp
++#define enc_jpeg2000 gdal_enc_jpeg2000
++#define enc_png gdal_enc_png
++#define extdrstemplate gdal_extdrstemplate
++#define extgridtemplate gdal_extgridtemplate
++#define extpdstemplate gdal_extpdstemplate
++#define frame_dummy gdal_frame_dummy
++#define g2_addfield gdal_g2_addfield
++#define g2_addgrid gdal_g2_addgrid
++#define g2_addlocal gdal_g2_addlocal
++#define g2_create gdal_g2_create
++#define g2_free gdal_g2_free
++#define g2_getfld gdal_g2_getfld
++#define g2_gribend gdal_g2_gribend
++#define g2_info gdal_g2_info
++#define g2_miss gdal_g2_miss
++#define g2_unpack1 gdal_g2_unpack1
++#define g2_unpack2 gdal_g2_unpack2
++#define g2_unpack3 gdal_g2_unpack3
++#define g2_unpack4 gdal_g2_unpack4
++#define g2_unpack5 gdal_g2_unpack5
++#define g2_unpack6 gdal_g2_unpack6
++#define g2_unpack7 gdal_g2_unpack7
++#define gbit gdal_gbit
++#define gbit2 gdal_gbit2
++#define gbits gdal_gbits
++#define getdim gdal_getdim
++#define getdrsindex gdal_getdrsindex
++#define getdrstemplate gdal_getdrstemplate
++#define getgridindex gdal_getgridindex
++#define getgridtemplate gdal_getgridtemplate
++#define getpdsindex gdal_getpdsindex
++#define getpdstemplate gdal_getpdstemplate
++#define getpoly gdal_getpoly
++#define get_templatesdrs gdal_get_templatesdrs
++#define get_templatesgrid gdal_get_templatesgrid
++#define get_templatespds gdal_get_templatespds
++#define int_power gdal_int_power
++#define jpcpack gdal_jpcpack
++#define jpcunpack gdal_jpcunpack
++#define misspack gdal_misspack
++#define mkieee gdal_mkieee
++#define pack_gp gdal_pack_gp
++#define pngpack gdal_pngpack
++#define pngunpack gdal_pngunpack
++#define rdieee gdal_rdieee
++#define reduce gdal_reduce
++#define sbit gdal_sbit
++#define sbits gdal_sbits
++#define seekgb gdal_seekgb
++#define simpack gdal_simpack
++#define simunpack gdal_simunpack
++#define specpack gdal_specpack
++#define specunpack gdal_specunpack
++#define templatesdrs gdal_templatesdrs
++#define templatesgrid gdal_templatesgrid
++#define templatespds gdal_templatespds
+diff -up gdal-3.0.2/frmts/grib/degrib/g2clib/grib2.h.orig gdal-3.0.2/frmts/grib/degrib/g2clib/grib2.h
+--- gdal-3.0.2/frmts/grib/degrib/g2clib/grib2.h.orig	2022-04-07 13:26:03.141929937 +0000
++++ gdal-3.0.2/frmts/grib/degrib/g2clib/grib2.h	2022-04-07 13:27:04.004706868 +0000
+@@ -3,6 +3,9 @@
+ #include<stdio.h>
+ 
+ #define G2_VERSION "g2clib-1.6.0"
++
++#include "gdal_g2clib_symbol_rename.h"
++
+ /*                .      .    .                                       .
+ //   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2002-10-25
+ //
+diff -up gdal-3.0.2/frmts/grib/rename_g2clib_symbols.sh.orig gdal-3.0.2/frmts/grib/rename_g2clib_symbols.sh
+--- gdal-3.0.2/frmts/grib/rename_g2clib_symbols.sh.orig	2022-04-07 13:27:40.037574797 +0000
++++ gdal-3.0.2/frmts/grib/rename_g2clib_symbols.sh	2022-04-07 13:35:09.184928108 +0000
+@@ -0,0 +1,38 @@
++#!/bin/sh
++
++SONAME=/tmp/g2clib.so
++
++gcc -fPIC -I../../port degrib/g2clib/*.c -shared -o $SONAME
++
++OUT_FILE=degrib/g2clib/gdal_g2clib_symbol_rename.h
++
++rm $OUT_FILE 2>/dev/null
++
++echo "/* This is a generated file by rename_g2clib_symbols.h. *DO NOT EDIT MANUALLY !* */" >> $OUT_FILE
++
++symbol_list=$(objdump -t $SONAME  | grep .text | awk '{print $6}' | grep -v -e .text -e __do_global -e __bss_start -e _edata -e _end -e _fini -e _init -e call_gmon_start  -e register_tm_clones | sort)
++
++for symbol in $symbol_list
++do
++    echo "#define $symbol gdal_$symbol" >> $OUT_FILE
++done
++
++rodata_symbol_list=$(objdump -t $SONAME  | grep "\\.rodata" |  awk '{print $6}' | grep -v "\\.")
++for symbol in $rodata_symbol_list
++do
++    echo "#define $symbol gdal_$symbol" >> $OUT_FILE
++done
++
++data_symbol_list=$(objdump -t $SONAME  | grep "\\.data"  | grep -v -e __dso_handle -e __TMC_END__ | awk '{print $6}' | grep -v "\\.")
++for symbol in $data_symbol_list
++do
++    echo "#define $symbol gdal_$symbol" >> $OUT_FILE
++done
++
++bss_symbol_list=$(objdump -t $SONAME  | grep "\\.bss" |  awk '{print $6}' | grep -v "\\.")
++for symbol in $bss_symbol_list
++do
++    echo "#define $symbol gdal_$symbol" >> $OUT_FILE
++done
++
++rm $SONAME


### PR DESCRIPTION
with original g2clib (with ncl for example)