### PR TITLE
build: remove system dependencies not required anymore in el8

### DIFF
--- a/layers/layer0_core/.system_dependencies
+++ b/layers/layer0_core/.system_dependencies
@@ -14,7 +14,6 @@ libglib-2.0.so.0()(64bit)@generic
 libICE.so.6()(64bit)@generic
 liblzma.so.5()(64bit)@generic
 libm.so.6()(64bit)@generic
-libncurses.so.5()(64bit)@generic
 libonig.so.5()(64bit)@generic
 libpcre.so.1()(64bit)@generic
 libpng16.so.16()(64bit)@generic
@@ -26,7 +25,6 @@ libsqlite3.so.0()(64bit)@generic
 libssl.so.1.1()(64bit)@generic
 libstdc++.so.6()(64bit)@generic
 libtcl8.6.so()(64bit)@generic
-libtinfo.so.5()(64bit)@generic
 libtk8.6.so()(64bit)@generic
 libX11.so.6()(64bit)@generic
 libXau.so.6()(64bit)@generic

--- a/layers/layer1_python3_core/.system_dependencies
+++ b/layers/layer1_python3_core/.system_dependencies
@@ -1,7 +1,5 @@
 libbz2.so.1()(64bit)@generic
 libcrypt.so.1()(64bit)@generic
 libfreebl3.so()(64bit)@generic
-libncursesw.so.5()(64bit)@generic
 libnsl.so.1()(64bit)@generic
 libutil.so.1()(64bit)@generic
-libpanelw.so.5()(64bit)@generic

--- a/layers/layer9_default/.system_dependencies
+++ b/layers/layer9_default/.system_dependencies
@@ -1,16 +1,10 @@
-which@centos6,centos7
-wget@centos6,centos7
-util-linux-ng@centos6
-util-linux@centos7
 libc.so.6()(64bit)@generic
 libdl.so.2()(64bit)@generic
 libgcc_s.so.1()(64bit)@generic
 libm.so.6()(64bit)@generic
-libncurses.so.5()(64bit)@generic
 libpthread.so.0()(64bit)@generic
 libresolv.so.2()(64bit)@generic
 librt.so.1()(64bit)@generic
-libtinfo.so.5()(64bit)@generic
 libz.so.1()(64bit)@generic
 libelf.so.1()(64bit)@generic
 libstdc++.so.6()(64bit)@generic


### PR DESCRIPTION
From package ncurses-compat-libs : 
- libtinfo.so.5
- libncurses.so.5
- libncursesw.so.5
- libpanelw.so.5