### PR TITLE
build: add libffi.so.6 in embedded system dependencies (for rocky 9)

### DIFF
--- a/layers/layer0_core/.system_dependencies
+++ b/layers/layer0_core/.system_dependencies
@@ -7,7 +7,6 @@ libdl.so.2()(64bit)@generic
 libelf.so.1()(64bit)@generic
 libexpat.so.1()(64bit)@generic
 libev.so.4()(64bit)@generic
-libffi.so.6()(64bit)@generic
 libfontconfig.so.1()(64bit)@generic
 libfreetype.so.6()(64bit)@generic
 libgcc_s.so.1()(64bit)@generic

--- a/layers/layer0_core/0001_scientific_system_libraries/libraries.txt
+++ b/layers/layer0_core/0001_scientific_system_libraries/libraries.txt
@@ -2,3 +2,5 @@
 /usr/lib64/libjson-c.so.4.0.0
 /usr/lib64/libevent-2.1.so.6
 /usr/lib64/libevent-2.1.so.6.0.2
+/usr/lib64/libffi.so.6
+/usr/lib64/libffi.so.6.0.2


### PR DESCRIPTION
(rockylinux:9 provides libffi.so.8)