### PR TITLE
build: add system dependency file

### DIFF
--- a/layers/layer0_core/.system_dependencies
+++ b/layers/layer0_core/.system_dependencies
@@ -41,5 +41,6 @@ libxslt.so.1()(64bit)@generic
 libXt.so.6()(64bit)@generic
 libz.so.1()(64bit)@generic
 /usr/bin/curl@generic
+/usr/bin/file@generic
 /usr/bin/wget@generic
 /usr/bin/which@generic


### PR DESCRIPTION
(not installed by default under modern linux distributions)