### PR TITLE
build: remove pytest-forked, not required anymore as dependency 

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -178,7 +178,6 @@
 | [PyScaffold](https://github.com/pyscaffold/pyscaffold/) | 4.3.1 | python3 |
 | [pytest-asyncio](https://github.com/pytest-dev/pytest-asyncio) | 0.20.1 | python3_devtools |
 | [pytest-cov](https://github.com/pytest-dev/pytest-cov) | 4.0.0 | python3_devtools |
-| [pytest-forked](https://github.com/pytest-dev/pytest-forked) | 1.4.0 | python3_devtools |
 | [pytest-html](https://github.com/pytest-dev/pytest-html) | 3.2.0 | python3_devtools |
 | [pytest-httpserver](https://github.com/csernazs/pytest-httpserver) | 1.0.6 | python3_devtools |
 | [pytest-metadata](https://github.com/pytest-dev/pytest-metadata) | 2.0.4 | python3_devtools |
@@ -251,4 +250,4 @@
 | [zeromq](https://zeromq.org/) | 4.3.4 | core |
 | [zipp](https://github.com/jaraco/zipp) | 3.8.1 | python3_core |
 
-*(250 components)*
+*(249 components)*

--- a/layers/layer7_python3_devtools/0500_extra_python_packages/requirements-to-freeze.txt
+++ b/layers/layer7_python3_devtools/0500_extra_python_packages/requirements-to-freeze.txt
@@ -22,6 +22,7 @@ pymdown-extensions
 pytest-cov
 pytest-xdist
 pytest-mock
+#py dependency should be removed when new pytest-html will be available
 pytest-html
 freezegun
 pytest-asyncio

--- a/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
@@ -50,7 +50,6 @@ pymdown-extensions==9.8
 pytest==7.2.0
 pytest-asyncio==0.20.1
 pytest-cov==4.0.0
-pytest-forked==3.2.0
 pytest-html==3.2.0
 pytest-httpserver==1.0.6
 pytest-metadata==2.0.4

--- a/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
@@ -50,6 +50,7 @@ pymdown-extensions==9.8
 pytest==7.2.0
 pytest-asyncio==0.20.1
 pytest-cov==4.0.0
+pytest-forked==3.2.0
 pytest-html==3.2.0
 pytest-httpserver==1.0.6
 pytest-metadata==2.0.4

--- a/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
@@ -50,7 +50,6 @@ pymdown-extensions==9.8
 pytest==7.2.0
 pytest-asyncio==0.20.1
 pytest-cov==4.0.0
-pytest-forked==1.4.0
 pytest-html==3.2.0
 pytest-httpserver==1.0.6
 pytest-metadata==2.0.4


### PR DESCRIPTION
(moreover its dependency py is not maintained anymore and has security issue)