### PR TITLE
fix: remove useless and dangerous call to mfxxx.init in mfxxx.start

### DIFF
--- a/adm/templates/mfxxx.start
+++ b/adm/templates/mfxxx.start
@@ -58,9 +58,9 @@ if test "${PLUGIN_NAME}" != ""; then
     exit 1
 fi
 if test "${NOINIT}" = "0"; then
-    if ! test -d ${MFMODULE_RUNTIME_HOME}/var/plugins; then
-        {{MFMODULE_LOWERCASE}}.init
-    fi
+#    if ! test -d ${MFMODULE_RUNTIME_HOME}/var/plugins; then
+#        {{MFMODULE_LOWERCASE}}.init
+#    fi
     {% if MFMODULE != "MFBASE" %}
     _install_or_update_configured_plugins.py
     {% endif %}

--- a/adm/templates/mfxxx.start
+++ b/adm/templates/mfxxx.start
@@ -58,9 +58,13 @@ if test "${PLUGIN_NAME}" != ""; then
     exit 1
 fi
 if test "${NOINIT}" = "0"; then
-#    if ! test -d ${MFMODULE_RUNTIME_HOME}/var/plugins; then
-#        {{MFMODULE_LOWERCASE}}.init
-#    fi
+    DIR_INIT="plugins"
+    {% if MFMODULE == "MFBASE" %}
+    DIR_INIT="pgsql"
+    {% endif %}
+    if ! test -d ${MFMODULE_RUNTIME_HOME}/var/${DIR_INIT}; then
+        {{MFMODULE_LOWERCASE}}.init
+    fi
     {% if MFMODULE != "MFBASE" %}
     _install_or_update_configured_plugins.py
     {% endif %}


### PR DESCRIPTION
Close: https://github.com/metwork-framework/mfbase/issues/238
We experiment the loss of a database for mfbase in a docker volumes context 
