### PR TITLE
fix: update redis to 4.3.6 to fix vulnerability

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -198,7 +198,7 @@
 | [pyzmq](https://pyzmq.readthedocs.org) | 22.3.0 | python3_circus |
 | [readline](https://www.gnu.org/software/readline) | 8.1.2 | core |
 | [redis](http://redis.io) | 5.0.5 | core |
-| [redis](https://github.com/redis/redis-py) | 4.3.4 | python3 |
+| [redis](https://github.com/redis/redis-py) | 4.3.6 | python3 |
 | [regex](https://github.com/mrabarnett/mrab-regex) | 2022.10.31 | python3 |
 | [repackage](https://www.settlenext.com) | 0.7.3 | python3_devtools |
 | [requests-unixsocket](https://github.com/msabramo/requests-unixsocket) | 0.3.0 | python3 |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -63,7 +63,7 @@ PyNaCl==1.5.0
 python-dateutil==2.8.2
 pytz==2022.5
 PyYAML==6.0
-redis==4.3.4
+redis==4.3.6
 regex==2022.10.31
 requests==2.28.1
 requests-unixsocket==0.3.0


### PR DESCRIPTION
Close: https://github.com/metwork-framework/mfext/security/dependabot/44