### PR TITLE
feat: bump aiohttp from 3.8.5 to 3.8.6 (security update)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -2,7 +2,7 @@
 | --- | --- | --- |
 | [acquisition](https://github.com/metwork-framework/acquisition) | 8205f0c | python3 |
 | [aiohttp-metwork-middlewares](https://github.com/metwork-framework/aiohttp_metwork_middlewares) | 6ec9424 | python3 |
-| [aiohttp](https://github.com/aio-libs/aiohttp) | 3.8.5 | python3 |
+| [aiohttp](https://github.com/aio-libs/aiohttp) | 3.8.6 | python3 |
 | [aiosignal](https://github.com/aio-libs/aiosignal) | 1.3.1 | python3 |
 | [annotated-types](https://pypi.org/project/annotated-types) | 0.6.0 | python3 |
 | [apipkg](https://pypi.org/project/apipkg) | 3.0.2 | python3_devtools |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/metwork-framework/acquisition.git@8205f0c2fcd323d7e36cbeecac05e74935def06c#egg=acquisition
-aiohttp==3.8.5
+aiohttp==3.8.6
 -e git+https://github.com/metwork-framework/aiohttp_metwork_middlewares.git@6ec9424f24b7b89298dfcabde36ad49332cbecc4#egg=aiohttp_metwork_middlewares
 aiosignal==1.3.1
 annotated-types==0.6.0


### PR DESCRIPTION
See https://github.com/metwork-framework/mfext/security/dependabot/77