### PR TITLE
build: fix openldap dependencies

### DIFF
--- a/layers/layer0_core/.system_dependencies
+++ b/layers/layer0_core/.system_dependencies
@@ -12,6 +12,8 @@ libfreetype.so.6()(64bit)@generic
 libgcc_s.so.1()(64bit)@generic
 libglib-2.0.so.0()(64bit)@generic
 libICE.so.6()(64bit)@generic
+liblber-2.4.so.2()(64bit)@generic
+libldap-2.4.so.2()(64bit)@generic
 liblzma.so.5()(64bit)@generic
 libm.so.6()(64bit)@generic
 libonig.so.5()(64bit)@generic

--- a/layers/layer7_python3_devtools/.system_dependencies
+++ b/layers/layer7_python3_devtools/.system_dependencies
@@ -1,1 +1,0 @@
-libldap-2.4.so.2()(64bit)@generic


### PR DESCRIPTION
libldap.so and liblber.so are required for many layers, not only python3_devtools