### PR TITLE
fix: set postgis extension as trusted

### DIFF
--- a/layers/layer1_scientific_core/0070_postgis/Makefile.mk
+++ b/layers/layer1_scientific_core/0070_postgis/Makefile.mk
@@ -25,3 +25,4 @@ $(PREFIX)/lib/postgresql/postgis-$(SHORT_VERSION).so:
 $(PREFIX)/contrib/postgis-$(SHORT_VERSION)/postgis_comments.sql:
 	mkdir -p $(PREFIX)/contrib/postgis-$(SHORT_VERSION)
 	cd build/$(NAME)-$(VERSION) && cp -f doc/postgis_comments.sql $(PREFIX)/contrib/postgis-$(SHORT_VERSION)/
+	echo "trusted = true" >> $(PREFIX)/share/postgresql/extension/postgis.control


### PR DESCRIPTION
Fix problem 2 of https://github.com/metwork-framework/mfbase/issues/265