### PR TITLE
feat: add libssl.so.1.1 and libcrypto.so.1.1 in embedded system dependencies

### DIFF
--- a/layers/layer0_core/.system_dependencies
+++ b/layers/layer0_core/.system_dependencies
@@ -1,7 +1,6 @@
 libc.so.6()(64bit)@generic
 libcares.so.2()(64bit)@generic
 libcgraph.so.6()(64bit)@generic
-libcrypto.so.1.1()(64bit)@generic
 libcurl.so.4()(64bit)@generic
 libdl.so.2()(64bit)@generic
 libelf.so.1()(64bit)@generic
@@ -23,7 +22,6 @@ libpthread.so.0()(64bit)@generic
 libresolv.so.2()(64bit)@generic
 librt.so.1()(64bit)@generic
 libSM.so.6()(64bit)@generic
-libssl.so.1.1()(64bit)@generic
 libstdc++.so.6()(64bit)@generic
 libtcl8.6.so()(64bit)@generic
 libtinfo.so.6()(64bit)@generic

--- a/layers/layer0_core/0001_scientific_system_libraries/libraries.txt
+++ b/layers/layer0_core/0001_scientific_system_libraries/libraries.txt
@@ -4,3 +4,7 @@
 /usr/lib64/libevent-2.1.so.6.0.2
 /usr/lib64/libffi.so.6
 /usr/lib64/libffi.so.6.0.2
+/usr/lib64/libssl.so.1.1
+/usr/lib64/libssl.so.1.1.1k
+/usr/lib64/libcrypto.so.1.1
+/usr/lib64/libcrypto.so.1.1.1k


### PR DESCRIPTION
(for installation on fedora >= 40)