### PR TITLE
feat: bump typing-extensions from 4.10.0 to 4.12.2

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -280,7 +280,7 @@
 | [traitlets](https://github.com/ipython/traitlets) | 5.9.0 | python3 |
 | [trove-classifiers](https://github.com/pypa/trove-classifiers) | 2023.8.7 | python3_core |
 | [typer](https://github.com/tiangolo/typer) | 0.9.0 | python3_devtools |
-| [typing_extensions](https://pypi.org/project/typing_extensions) | 4.10.0 | python3_core |
+| [typing_extensions](https://pypi.org/project/typing_extensions) | 4.12.2 | python3_core |
 | [typing_inspect](https://github.com/ilevkivskyi/typing_inspect) | 0.9.0 | python3_devtools |
 | [Unidecode](https://pypi.org/project/Unidecode) | 1.3.6 | python3 |
 | [urllib3](https://pypi.org/project/urllib3) | 2.2.2 | python3 |

--- a/layers/layer1_python3_core/0410_prereq_extra_python_packages/requirements3.txt
+++ b/layers/layer1_python3_core/0410_prereq_extra_python_packages/requirements3.txt
@@ -1,3 +1,3 @@
 calver==2022.6.26
 setuptools-scm==8.1.0
-typing-extensions==4.10.0
+typing-extensions==4.12.2


### PR DESCRIPTION
(python 3.13 compatibility for pydantic)