### PR TITLE
feat: upgrade trove-classifiers to 2024.10.16 (for Pillow 11.0.0)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -280,7 +280,7 @@
 | [tornado](http://www.tornadoweb.org/) | 6.4.1 | python3 |
 | [tqdm](https://tqdm.github.io) | 4.66.4 | python3 |
 | [traitlets](https://github.com/ipython/traitlets) | 5.9.0 | python3 |
-| [trove-classifiers](https://github.com/pypa/trove-classifiers) | 2023.8.7 | python3_core |
+| [trove-classifiers](https://github.com/pypa/trove-classifiers) | 2024.10.16 | python3_core |
 | [typer](https://github.com/tiangolo/typer) | 0.9.0 | python3_devtools |
 | [typing_extensions](https://pypi.org/project/typing_extensions) | 4.12.2 | python3_core |
 | [typing_inspect](https://github.com/ilevkivskyi/typing_inspect) | 0.9.0 | python3_devtools |

--- a/layers/layer1_python3_core/0420_prereq_extra_python_packages/requirements3.txt
+++ b/layers/layer1_python3_core/0420_prereq_extra_python_packages/requirements3.txt
@@ -1,4 +1,4 @@
 pathspec==0.11.2
 pluggy==1.3.0
 toml==0.10.2
-trove-classifiers==2023.8.7
+trove-classifiers==2024.10.16


### PR DESCRIPTION
(see https://github.com/python-pillow/Pillow/issues/8470)