### PR TITLE
feat: revert "bump packaging from 24.2 to 25.0" (because of lightning)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -173,7 +173,7 @@
 | [openresty](http://openresty.org) | 1.15.8.4 | openresty |
 | [openssl](https://www.openssl.org/) | 3.4.1 | core |
 | [opinionated_configparser](https://github.com/metwork-framework/opinionated_configparser) | 1.0.1 | python3 |
-| [packaging](https://pypi.org/project/packaging) | 25.0 | python3_core |
+| [packaging](https://pypi.org/project/packaging) | 24.2 | python3_core |
 | [paginate](https://github.com/Signum/paginate) | 0.5.7 | python3_devtools |
 | [panoply](https://github.com/jeremynac/panoply) | 0.1.56 | python3_devtools |
 | [paramiko](https://paramiko.org) | 3.5.1 | python3 |

--- a/layers/layer1_python3_core/0405_prereq_extra_python_packages/requirements3.txt
+++ b/layers/layer1_python3_core/0405_prereq_extra_python_packages/requirements3.txt
@@ -1,1 +1,1 @@
-packaging==25.0
+packaging==24.2


### PR DESCRIPTION
This reverts commit a02b608d4d2987262cdde3415075dff7d2616547.