### PR TITLE
build: Revert (for test) upgrade telegraf from 1.13.3 to 1.36.2

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -285,7 +285,7 @@
 | [super_collections](https://pypi.org/project/super_collections) | 0.5.3 | python3_devtools |
 | [tcping](http://linuxco.de) | 1.3.5 | core |
 | [telegraf-unixsocket-client](https://github.com/metwork-framework/telegraf-unixsocket-python-client) | fc4b76c | python3 |
-| [telegraf](https://github.com/influxdata/telegraf) | 1.36.2 | monitoring |
+| [telegraf](https://github.com/influxdata/telegraf) | 1.13.3-1 | monitoring |
 | [termcolor](https://github.com/termcolor/termcolor) | 2.5.0 | python3 |
 | [terminaltables3](https://github.com/matthewdeanmartin/terminaltables3) | 4.0.0 | python3 |
 | [the_silver_searcher](https://github.com/ggreer/the_silver_searcher) | 2.2.0 | devtools |

--- a/layers/layer8_monitoring/0300_telegraf/Makefile.mk
+++ b/layers/layer8_monitoring/0300_telegraf/Makefile.mk
@@ -2,11 +2,11 @@ include ../../../adm/root.mk
 include ../../package.mk
 
 export NAME=telegraf
-export VERSION=1.36.2
+export VERSION=1.13.3-1
 export EXTENSION=tar.gz
 export CHECKTYPE=MD5
-export CHECKSUM=1833ec7ed8d696b04d0bbc3a5211593b
-export ARCHIVE=telegraf-$(VERSION)_linux_amd64.tar.gz
+export CHECKSUM=c4e9024da0221a663449994d8719da89
+export ARCHIVE=telegraf-1.13.3_linux_amd64.tar.gz
 DESCRIPTION=\
 influxdb plugin-driven server agent for collecting and reporting metrics.
 WEBSITE=https://github.com/influxdata/telegraf
@@ -16,4 +16,4 @@ all:: $(PREFIX)/bin/telegraf
 $(PREFIX)/bin/telegraf:
 	@mkdir -p $(PREFIX)/bin
 	$(MAKE) --file=$(MFEXT_HOME)/share/Makefile.standard PREFIX=$(PREFIX) download uncompress
-	cd build/$(NAME)-$(VERSION) && cp -f usr/bin/telegraf $@
+	cd build/$(NAME) && cp -f usr/bin/telegraf $@

--- a/layers/layer8_monitoring/0300_telegraf/sources
+++ b/layers/layer8_monitoring/0300_telegraf/sources
@@ -1,1 +1,1 @@
-https://dl.influxdata.com/telegraf/releases/telegraf-1.36.2_linux_amd64.tar.gz
+https://dl.influxdata.com/telegraf/releases/telegraf-1.13.3_linux_amd64.tar.gz


### PR DESCRIPTION
This reverts commit be6d881e5325dc007a03505c0be972e89e631f99.