### PR TITLE
feat: modules' home directory is now outside Metwork rpms

### DIFF
--- a/adm/_metwork.spec
+++ b/adm/_metwork.spec
@@ -262,7 +262,6 @@ rm -f mf*_link
         if test ${N} -eq 0; then
             echo "INFO: creating {{MFMODULE_LOWERCASE}} unix local user"
             useradd -d /home/{{MFMODULE_LOWERCASE}} -g metwork -s /bin/bash {{MFMODULE_LOWERCASE}} >/dev/null 2>&1 || true
-            rm -Rf /home/{{MFMODULE_LOWERCASE}}
             chown -R {{MFMODULE_LOWERCASE}}:metwork /home/{{MFMODULE_LOWERCASE}}.rpmsave* >/dev/null 2>&1 || true
         fi
     {% endif %}
@@ -283,48 +282,13 @@ rm -f mf*_link
 echo "INFO: install section"
 mkdir -p %{buildroot}/{{MFMODULE_HOME}} 2>/dev/null
 ln -s {{MFMODULE_HOME}} %{buildroot}{{TARGET_LINK}}
-{% if MODULE_HAS_HOME_DIR == "1" %}
-    mkdir -p %{buildroot}/home/{{MFMODULE_LOWERCASE}} 2>/dev/null
-{% endif %}
 mv metwork-{{MFMODULE_LOWERCASE}}-%{version}-{{RELEASE_BUILD}}/{{MFMODULE_LOWERCASE}}-%{version}-{{RELEASE_BUILD}}/* %{buildroot}{{MFMODULE_HOME}}/
 mv metwork-{{MFMODULE_LOWERCASE}}-%{version}-{{RELEASE_BUILD}}/{{MFMODULE_LOWERCASE}}-%{version}-{{RELEASE_BUILD}}/.layerapi2* %{buildroot}{{MFMODULE_HOME}}/ 2>/dev/null || true
 mv metwork-{{MFMODULE_LOWERCASE}}-%{version}-{{RELEASE_BUILD}}/{{MFMODULE_LOWERCASE}}-%{version}-{{RELEASE_BUILD}}/.dhash* %{buildroot}{{MFMODULE_HOME}}/ 2>/dev/null || true
 rm -Rf %{buildroot}{{MFMODULE_HOME}}/html_doc
-{% if MODULE_HAS_HOME_DIR == "1" %}
-    ln -s {{MFMODULE_HOME}}/share/bashrc %{buildroot}/home/{{MFMODULE_LOWERCASE}}/.bashrc
-    ln -s {{MFMODULE_HOME}}/share/bash_profile %{buildroot}/home/{{MFMODULE_LOWERCASE}}/.bash_profile
-    chmod -R go-rwx %{buildroot}/home/{{MFMODULE_LOWERCASE}}
-    chmod -R u+rX %{buildroot}/home/{{MFMODULE_LOWERCASE}}
-    {% if MFMODULE == "MFDATA" %}
-        chmod g+rx %{buildroot}/home/{{MFMODULE_LOWERCASE}}
-    {% endif %}
-{% endif %}
 chmod -R a+rX %{buildroot}{{MFMODULE_HOME}}
 rm -Rf %{_builddir}/%{name}-%{version}-{{RELEASE_BUILD}} 2>/dev/null
 
-
-{% if MFEXT_ADDON == "0" %}
-############################################################
-##### post SECTION (POSTINSTALLATION) FOR MAIN PACKAGE #####
-############################################################
-%post
-    echo "INFO: postinstall SECTION"
-    {% if MFMODULE != "MFEXT" %}
-        if test -f /home/.home_{{MFMODULE_LOWERCASE}}.perm; then
-            #Restore permissions of a previous install on /home/{{MFMODULE_LOWERCASE}}
-            echo "INFO : restoring permissions on /home/{{MFMODULE_LOWERCASE}}"
-            chmod --reference=/home/.home_{{MFMODULE_LOWERCASE}}.perm /home/{{MFMODULE_LOWERCASE}}
-        fi
-        if test -f /home/.home_{{MFMODULE_LOWERCASE}}.acl; then
-            #Restore ACLs of a previous install on /home/{{MFMODULE_LOWERCASE}}
-            echo "INFO : restoring ACLs on /home/{{MFMODULE_LOWERCASE}}"
-            if test -f /home/.home_{{MFMODULE_LOWERCASE}}.Racl; then
-                cd /home/{{MFMODULE_LOWERCASE}} && setfacl --restore=/home/.home_{{MFMODULE_LOWERCASE}}.Racl >/dev/null 2>&1
-            fi
-            cd /home/{{MFMODULE_LOWERCASE}} && setfacl --restore=/home/.home_{{MFMODULE_LOWERCASE}}.acl
-        fi
-    {% endif %}
-{% endif %}
 
 {% if MFEXT_ADDON == "0" %}
 #####################################################################
@@ -370,12 +334,36 @@ rm -Rf %{_builddir}/%{name}-%{version}-{{RELEASE_BUILD}} 2>/dev/null
             fi
         fi
     {% endif %}
-    {% if MFMODULE == "MFDATA" %}
-        mkdir -p /home/{{MFMODULE_LOWERCASE}}/var/in >/dev/null 2>&1
-        chown -R {{MFMODULE_LOWERCASE}}:metwork /home/{{MFMODULE_LOWERCASE}}/var >/dev/null 2>&1
-        chmod g+rX /home/{{MFMODULE_LOWERCASE}} >/dev/null 2>&1
-        chmod g+rX /home/{{MFMODULE_LOWERCASE}}/var >/dev/null 2>&1
-        chmod g+rX /home/{{MFMODULE_LOWERCASE}}/var/in >/dev/null 2>&1
+    {% if MFMODULE != "MFEXT" %}
+        if test -d /home/{{MFMODULE_LOWERCASE}}; then
+            echo "INFO: /home/{{MFMODULE_LOWERCASE}} is existing, we don't change any permission"
+            rm -f /home/{{MFMODULE_LOWERCASE}}/.bashrc
+            ln -s {{MFMODULE_HOME}}/share/bashrc /home/{{MFMODULE_LOWERCASE}}/.bashrc 
+            chown {{MFMODULE_LOWERCASE}}:metwork /home/{{MFMODULE_LOWERCASE}}/.bashrc
+            rm -f /home/{{MFMODULE_LOWERCASE}}/.bash_profile
+            ln -s {{MFMODULE_HOME}}/share/bash_profile /home/{{MFMODULE_LOWERCASE}}/.bash_profile 
+            chown {{MFMODULE_LOWERCASE}}:metwork /home/{{MFMODULE_LOWERCASE}}/.bash_profile
+        else
+            echo "INFO: Creating /home/{{MFMODULE_LOWERCASE}} with default permissions"
+            mkdir -p /home/{{MFMODULE_LOWERCASE}}
+            ln -s {{MFMODULE_HOME}}/share/bashrc /home/{{MFMODULE_LOWERCASE}}/.bashrc 
+            ln -s {{MFMODULE_HOME}}/share/bash_profile /home/{{MFMODULE_LOWERCASE}}/.bash_profile 
+            chmod -R go-rwx /home/{{MFMODULE_LOWERCASE}}
+            chmod -R u+rX /home/{{MFMODULE_LOWERCASE}}
+            {% if MFMODULE == "MFDATA" %}
+                chmod g+rx /home/{{MFMODULE_LOWERCASE}}
+                chmod o+x /home/{{MFMODULE_LOWERCASE}}
+            {% endif %}
+        fi
+        {% if MFMODULE == "MFDATA" %}
+            if ! test -d /home/{{MFMODULE_LOWERCASE}}/var/in
+                mkdir -p /home/{{MFMODULE_LOWERCASE}}/var/in >/dev/null 2>&1
+                chown -R {{MFMODULE_LOWERCASE}}:metwork /home/{{MFMODULE_LOWERCASE}}/var >/dev/null 2>&1
+                chmod g+rX /home/{{MFMODULE_LOWERCASE}} >/dev/null 2>&1
+                chmod g+rX /home/{{MFMODULE_LOWERCASE}}/var >/dev/null 2>&1
+                chmod g+rX /home/{{MFMODULE_LOWERCASE}}/var/in >/dev/null 2>&1
+            fi
+        {% endif %}
     {% endif %}
     {% if MFMODULE != "MFEXT" %}
         if test -d /etc/security/limits.d; then
@@ -411,17 +399,6 @@ EOF
     {% if MODULE_HAS_HOME_DIR == "1" %}
         #Remove system crontab (it will be rebuilt by module start and it may fix #1557)
         crontab -r -u {{MFMODULE_LOWERCASE}} || true
-        if test -d /home/{{MFMODULE_LOWERCASE}}; then
-            #File to keep permissions of /home/{{MFMODULE_LOWERCASE}} to be able to restore it
-            echo "INFO: saving /home/{{MFMODULE_LOWERCASE}} permissions"
-            touch /home/.home_{{MFMODULE_LOWERCASE}}.perm
-            chmod --reference=/home/{{MFMODULE_LOWERCASE}} /home/.home_{{MFMODULE_LOWERCASE}}.perm
-            chown --reference=/home/{{MFMODULE_LOWERCASE}} /home/.home_{{MFMODULE_LOWERCASE}}.perm
-            #Files to keep ACLs on /home/{{MFMODULE_LOWERCASE}} to be able to restore them
-            echo "INFO: saving ACLs on /home/{{MFMODULE_LOWERCASE}}"
-            cd /home/{{MFMODULE_LOWERCASE}} && getfacl -R . > /home/.home_{{MFMODULE_LOWERCASE}}.Racl
-            cd /home/{{MFMODULE_LOWERCASE}} && getfacl . > /home/.home_{{MFMODULE_LOWERCASE}}.acl
-        fi
     {% endif %}
     if [ "$1" = "0" ]; then # last uninstall only
         rm -Rf {{MFMODULE_HOME}} 2>/dev/null
@@ -461,10 +438,6 @@ rm -fr %{buildroot}
 %files
 %defattr(-,root,root,-)
 {{TARGET_LINK}}
-{% if MODULE_HAS_HOME_DIR == "1" %}
-%defattr(-,{{MFMODULE_LOWERCASE}},metwork,-)
-/home/{{MFMODULE_LOWERCASE}}
-{% endif %}
 
 
 {% if MFEXT_ADDON == "0" %}


### PR DESCRIPTION
It allows to keep permissions on already installed  home directory
If not existing, the home directory is created with default permissions in post installation