### PR TITLE
feat: bump Werkzeug from 3.1.4 to 3.1.5 (fix moderate CVE-2026-21860)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -311,7 +311,7 @@
 | [watchdog](https://github.com/gorakhargosh/watchdog) | 6.0.0 | python3_devtools |
 | [wcmatch](https://github.com/facelessuser/wcmatch) | 10.0 | python3_devtools |
 | [wcwidth](https://github.com/jquast/wcwidth) | 0.2.13 | python3 |
-| [Werkzeug](https://pypi.org/project/Werkzeug) | 3.1.4 | python3 |
+| [Werkzeug](https://pypi.org/project/Werkzeug) | 3.1.5 | python3 |
 | [wheel](https://pypi.org/project/wheel) | 0.45.1 | python3_core |
 | [wrapt](https://github.com/GrahamDumpleton/wrapt) | 1.17.2 | python3 |
 | [wrk](https://github.com/wg/wrk) | 4.2.0 | devtools |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -128,7 +128,7 @@ typing_inspection==0.4.2
 Unidecode==1.3.8
 urllib3==2.6.3
 wcwidth==0.2.13
-Werkzeug==3.1.4
+Werkzeug==3.1.5
 wrapt==1.17.2
 -e git+https://github.com/metwork-framework/xattrfile.git@857ae661ddf25da7c00964debd5f279d8303c622#egg=xattrfile
 xmltodict==0.14.2


### PR DESCRIPTION
(this CVE is only potentially active on Windows)