### PR TITLE
feat: Revert "feat: bump Click from 8.2.1 to 8.3.1 (#2572)"

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -40,7 +40,7 @@
 | [charset-normalizer](https://pypi.org/project/charset-normalizer) | 3.4.4 | python3 |
 | [circus](https://pypi.org/project/circus) | 6fdf573 | python3_circus |
 | [circus_autorestart_plugin](https://github.com/metwork-framework/circus_autorestart_plugin) | 86ff062 | python3_circus |
-| [click](https://pypi.org/project/click) | 8.3.1 | python3 |
+| [click](https://pypi.org/project/click) | 8.2.1 | python3 |
 | [colorama](https://github.com/tartley/colorama) | 0.4.6 | python3 |
 | [ConfigUpdater](https://github.com/pyscaffold/configupdater) | 3.2 | python3 |
 | [cookiecutter](https://github.com/metwork-framework/cookiecutter) | 39a141b | python3 |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -21,7 +21,7 @@ cachetools==5.5.2
 Cerberus==1.3.7
 chardet==5.2.0
 charset_normalizer==3.4.4
-Click==8.3.1
+Click==8.2.1
 colorama==0.4.6
 -e git+https://github.com/metwork-framework/cookiecutter.git@39a141b88e50d1b927e792dd58dad24aacbbad91#egg=cookiecutter
 -e git+https://github.com/metwork-framework/cookiecutter_hooks.git@22817e1a4051cd8141dc963cde4119f65c2fae04#egg=cookiecutter_hooks


### PR DESCRIPTION
(copernicusmarine on python3_scientific layer requires click<8.3.0)