### PR TITLE
feat: bump openssl from 3.5.4 to 3.5.5 (fix several CVE)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -174,7 +174,7 @@
 | [openjdk](https://adoptium.net/fr/) | 21.0.7+6 | java |
 | [openldap](https://www.openldap.org/) | 2.6.9 | core |
 | [openresty](http://openresty.org) | 1.27.1.2 | openresty |
-| [openssl](https://www.openssl.org/) | 3.5.4 | core |
+| [openssl](https://www.openssl.org/) | 3.5.5 | core |
 | [opinionated_configparser](https://github.com/metwork-framework/opinionated_configparser) | 1.0.1 | python3 |
 | [orjson](https://pypi.org/project/orjson) | 3.11.4 | python3 |
 | [packaging](https://pypi.org/project/packaging) | 25.0 | python3_core |

--- a/layers/layer0_core/0025_openssl/Makefile.mk
+++ b/layers/layer0_core/0025_openssl/Makefile.mk
@@ -2,10 +2,10 @@ include ../../../adm/root.mk
 include ../../package.mk
 
 export NAME=openssl
-export VERSION=3.5.4
+export VERSION=3.5.5
 export EXTENSION=tar.gz
 export CHECKTYPE=MD5
-export CHECKSUM=570a7ab371147b6ba72c6d0fed93131f
+export CHECKSUM=9c86d929c3d1067e2c88239d7d1ce81b
 DESCRIPTION=\
 OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the TLS (formerly SSL), DTLS and QUIC protocols
 WEBSITE=https://www.openssl.org/

--- a/layers/layer0_core/0025_openssl/sources
+++ b/layers/layer0_core/0025_openssl/sources
@@ -1,1 +1,1 @@
-https://github.com/openssl/openssl/releases/download/openssl-3.5.4/openssl-3.5.4.tar.gz
+https://github.com/openssl/openssl/releases/download/openssl-3.5.5/openssl-3.5.5.tar.gz


### PR DESCRIPTION
CVE fixed : 
- CVE-2025-11187 (moderate)
- CVE-2025-15467 (high)
- CVE-2025-15468 (low)
- CVE-2025-15469 (low)
- CVE-2025-66199 (low)
- CVE-2025-68160 (low)
- CVE-2025-69418 (low)
- CVE-2025-69419 (low)
- CVE-2025-69420 (low)
- CVE-2025-69421 (low)
- CVE-2026-22795 (low)
- CVE-2026-22796 (low)