### PR TITLE
build: move typing-inspect from python3_devtools to python3 layer

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -301,7 +301,7 @@
 | [types-python-dateutil](https://github.com/python/typeshed) | 2.9.0.20241206 | python3 |
 | [typing-inspection](https://github.com/pydantic/typing-inspection) | 0.4.2 | python3 |
 | [typing_extensions](https://pypi.org/project/typing_extensions) | 4.15.0 | python3_core |
-| [typing_inspect](https://github.com/ilevkivskyi/typing_inspect) | 0.9.0 | python3_devtools |
+| [typing_inspect](https://github.com/ilevkivskyi/typing_inspect) | 0.9.0 | python3 |
 | [Unidecode](https://pypi.org/project/Unidecode) | 1.3.8 | python3 |
 | [urllib3](https://pypi.org/project/urllib3) | 2.6.3 | python3 |
 | [vector](https://vector.dev/) | 0.49.0 | monitoring |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements-to-freeze.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements-to-freeze.txt
@@ -85,3 +85,4 @@ scikit-build-core
 typer
 aiofiles
 msgpack
+typing-inspect

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -124,6 +124,7 @@ tqdm==4.67.1
 traitlets==5.14.3
 typer==0.16.0
 types-python-dateutil==2.9.0.20241206
+typing_inspect==0.9.0
 typing_inspection==0.4.2
 Unidecode==1.3.8
 urllib3==2.6.3

--- a/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
@@ -76,6 +76,5 @@ snowballstemmer==2.2.0
 stevedore==5.4.1
 super-collections==0.5.3
 tox==4.28.4
-typing-inspect==0.9.0
 watchdog==6.0.0
 wcmatch==10.0


### PR DESCRIPTION
(dependency both required in python3_devtools and python3_ia)