### PR TITLE
feat: bump cryptography to 46.0.5 (fix high CVE-2026-26007)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -46,7 +46,7 @@
 | [cookiecutter_hooks](https://github.com/metwork-framework/cookiecutter_hooks) | 22817e1 | python3 |
 | [coverage](https://github.com/nedbat/coveragepy) | 7.7.1 | python3_devtools |
 | [cron-wrapper](https://github.com/metwork-framework/cron-wrapper) | 0.1.3 | python3 |
-| [cryptography](https://github.com/pyca/cryptography) | 46.0.4 | python3 |
+| [cryptography](https://github.com/pyca/cryptography) | 46.0.5 | python3 |
 | [curl](https://curl.haxx.se/) | 7.88.1 | core |
 | [cyrus-sasl](https://www.cyrusimap.org/sasl/) | 2.1.28 | core |
 | [Cython](https://cython.org/) | 3.2.4 | python3 |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -26,7 +26,7 @@ colorama==0.4.6
 -e git+https://github.com/metwork-framework/cookiecutter.git@39a141b88e50d1b927e792dd58dad24aacbbad91#egg=cookiecutter
 -e git+https://github.com/metwork-framework/cookiecutter_hooks.git@22817e1a4051cd8141dc963cde4119f65c2fae04#egg=cookiecutter_hooks
 cron-wrapper==0.1.3
-cryptography==46.0.4
+cryptography==46.0.5
 decorator==5.2.1
 defusedxml==0.7.1
 -e git+https://github.com/metwork-framework/deploycron.git@3d103a7d0cdaa1f21f6df994f181227e0d43329b#egg=deploycron


### PR DESCRIPTION
Close: https://github.com/metwork-framework/mfext/security/dependabot/188