### PR TITLE
feat: bump wrapt from 1.17.2 to 2.1.1

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -53,7 +53,7 @@
 | [decorator](https://pypi.org/project/decorator) | 5.2.1 | python3 |
 | [defusedxml](https://github.com/tiran/defusedxml) | 0.7.1 | python3 |
 | [deploycron](https://github.com/metwork-framework/deploycron) | 3d103a7 | python3 |
-| [Deprecated](https://github.com/laurent-laporte-pro/deprecated) | 1.2.18 | python3 |
+| [Deprecated](https://github.com/laurent-laporte-pro/deprecated) | 1.3.1 | python3 |
 | [deprecation](http://deprecation.readthedocs.io/) | 2.1.0 | python3 |
 | [dill](https://github.com/uqfoundation/dill) | 0.4.0 | python3 |
 | [directory_observer](https://github.com/metwork-framework/directory_observer) | 2c499bd | python3 |
@@ -313,7 +313,7 @@
 | [wcwidth](https://github.com/jquast/wcwidth) | 0.2.13 | python3 |
 | [Werkzeug](https://pypi.org/project/Werkzeug) | 3.1.6 | python3 |
 | [wheel](https://pypi.org/project/wheel) | 0.46.3 | python3_core |
-| [wrapt](https://github.com/GrahamDumpleton/wrapt) | 1.17.2 | python3 |
+| [wrapt](https://github.com/GrahamDumpleton/wrapt) | 2.1.1 | python3 |
 | [wrk](https://github.com/wg/wrk) | 4.2.0 | devtools |
 | [wrk2](https://github.com/giltene/wrk2) | master20191107 | devtools |
 | [xattrfile](https://github.com/metwork-framework/xattrfile) | 857ae66 | python3 |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -30,7 +30,7 @@ cryptography==46.0.5
 decorator==5.2.1
 defusedxml==0.7.1
 -e git+https://github.com/metwork-framework/deploycron.git@3d103a7d0cdaa1f21f6df994f181227e0d43329b#egg=deploycron
-Deprecated==1.2.18
+Deprecated==1.3.1
 deprecation==2.1.0
 dill==0.4.0
 -e git+https://github.com/metwork-framework/directory_observer.git@2c499bde00de6868cb850e3aa2e10a1c4557f6dc#egg=directory_observer
@@ -130,7 +130,7 @@ Unidecode==1.3.8
 urllib3==2.6.3
 wcwidth==0.2.13
 Werkzeug==3.1.6
-wrapt==1.17.2
+wrapt==2.1.1
 -e git+https://github.com/metwork-framework/xattrfile.git@857ae661ddf25da7c00964debd5f279d8303c622#egg=xattrfile
 xmltodict==0.14.2
 yarl==1.18.3


### PR DESCRIPTION
It requires to bump Deprecated from 1.2.18 to 1.3.1