### PR TITLE
feat: bump tornado from 6.5.4 to 6.5.5 (fix high CVE-2026-31958)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -300,7 +300,7 @@
 | [the_silver_searcher](https://github.com/ggreer/the_silver_searcher) | 2.2.0 | devtools |
 | [threadpoolctl](https://github.com/joblib/threadpoolctl) | 3.6.0 | python3 |
 | [tomlkit](https://github.com/sdispater/tomlkit) | 0.13.2 | python3 |
-| [tornado](http://www.tornadoweb.org/) | 6.5.4 | python3 |
+| [tornado](http://www.tornadoweb.org/) | 6.5.5 | python3 |
 | [tox](http://tox.readthedocs.org) | 4.28.4 | python3_devtools |
 | [tqdm](https://tqdm.github.io) | 4.67.1 | python3 |
 | [traitlets](https://github.com/ipython/traitlets) | 5.14.3 | python3 |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -118,7 +118,7 @@ structlog==23.1.0
 termcolor==2.5.0
 terminaltables3==4.0.0
 threadpoolctl==3.6.0
-tornado==6.5.4
+tornado==6.5.5
 tqdm==4.67.1
 traitlets==5.14.3
 typer==0.16.0


### PR DESCRIPTION
also fix GHSA-78cv-mqj4-43f7
Close: https://github.com/metwork-framework/mfext/security/dependabot/198
Close: https://github.com/metwork-framework/mfext/security/dependabot/197