### PR TITLE
feat: bump aiohttp from 3.13.3 to 3.13.5 (fix various CVEs)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -3,7 +3,7 @@
 | [acquisition](https://github.com/metwork-framework/acquisition) | 78a05cb | python3 |
 | [aiofiles](https://pypi.org/project/aiofiles) | 24.1.0 | python3 |
 | [aiohappyeyeballs](https://pypi.org/project/aiohappyeyeballs) | 2.5.0 | python3 |
-| [aiohttp](https://github.com/aio-libs/aiohttp) | 3.13.3 | python3 |
+| [aiohttp](https://github.com/aio-libs/aiohttp) | 3.13.5 | python3 |
 | [aiohttp_metwork_middlewares](https://github.com/metwork-framework/aiohttp_metwork_middlewares) | 3ef444a | python3 |
 | [aiosignal](https://github.com/aio-libs/aiosignal) | 1.4.0 | python3 |
 | [altgraph](https://altgraph.readthedocs.io) | 0.17.5 | python3_devtools |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -1,7 +1,7 @@
 -e git+https://github.com/metwork-framework/acquisition.git@78a05cb1dee0eb305751cd08c27b014d7b26c912#egg=acquisition
 aiofiles==24.1.0
 aiohappyeyeballs==2.5.0
-aiohttp==3.13.3
+aiohttp==3.13.5
 -e git+https://github.com/metwork-framework/aiohttp_metwork_middlewares.git@3ef444a64f23bdc69bf93d4a5997d2bda11dd02a#egg=aiohttp_metwork_middlewares
 aiosignal==1.4.0
 annotated-types==0.7.0


### PR DESCRIPTION
CVE fixed :
- CVE-2026-22815 (moderate)
- CVE-2026-34513 (low)
- CVE-2026-34514 (low)
- CVE-2026-34515 (moderate)
- CVE-2026-34516 (moderate)
- CVE-2026-34517 (low)
- CVE-2026-34518 (low)
- CVE-2026-34519 (low)
- CVE-2026-34520 (low)
- CVE-2026-34525 (moderate)