### PR TITLE
feat: bump openresty from 1.27.1.2 to 1.29.2.3 (fix nginx CVEs)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -180,7 +180,7 @@
 | [nodejs](http://nodejs.org) | 22.16.0 | nodejs |
 | [openjdk](https://adoptium.net/fr/) | 21.0.7+6 | java |
 | [openldap](https://www.openldap.org/) | 2.6.9 | core |
-| [openresty](http://openresty.org) | 1.27.1.2 | openresty |
+| [openresty](http://openresty.org) | 1.29.2.3 | openresty |
 | [openssl](https://www.openssl.org/) | 3.5.5 | core |
 | [opinionated_configparser](https://github.com/metwork-framework/opinionated_configparser) | 1.0.1 | python3 |
 | [orjson](https://pypi.org/project/orjson) | 3.11.7 | python3 |

--- a/layers/layer1_openresty/0100_openresty/Makefile.mk
+++ b/layers/layer1_openresty/0100_openresty/Makefile.mk
@@ -2,17 +2,15 @@ include ../../../adm/root.mk
 include ../../package.mk
 
 export NAME=openresty
-export VERSION=1.27.1.2
+export VERSION=1.29.2.3
 export EXTENSION=tar.gz
 export CHECKTYPE=MD5
-export CHECKSUM=db41e79230e849cf19c075059f4bf62b
+export CHECKSUM=965e11087a9a998b69b7d68d644a5824
 DESCRIPTION=\
 OpenResty - Turning Nginx into a Full-Fledged Scriptable Web Platform
 WEBSITE=http://openresty.org
 LICENSE=BSD
 
-#Version 1.15.8.4 does not exist : it's 1.15.8.3 with patch on CVE-2020-11724
-#export SOURCE_VERSION=1.15.8.3
 export EXPLICIT_NAME=$(NAME)-$(VERSION)
 
 export SSL_CFLAGS=$(shell pkg-config --cflags openssl)

--- a/layers/layer1_openresty/0100_openresty/sources
+++ b/layers/layer1_openresty/0100_openresty/sources
@@ -1,1 +1,1 @@
-https://openresty.org/download/openresty-1.27.1.2.tar.gz
+https://openresty.org/download/openresty-1.29.2.3.tar.gz


### PR DESCRIPTION
CVE fixed :
- CVE-2026-27654 (high)
- CVE-2026-27784 (high)
- CVE-2026-32647 (high)
- CVE-2026-27651 (high)
- CVE-2026-28753 (medium)
- CVE-2026-28755 (medium)
- CVE-2026-1642 (high)
- CVE-2025-53859 (medium)