### PR TITLE
feat: bump openssl from 3.5.5 to 3.6.2 (fix 8 CVE, moderate or less)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -168,7 +168,7 @@
 | [openjdk](https://adoptium.net/fr/) | 21.0.7+6 | java |
 | [openldap](https://www.openldap.org/) | 2.6.9 | core |
 | [openresty](http://openresty.org) | 1.29.2.3 | openresty |
-| [openssl](https://www.openssl.org/) | 3.5.5 | core |
+| [openssl](https://www.openssl.org/) | 3.6.2 | core |
 | [opinionated_configparser](https://github.com/metwork-framework/opinionated_configparser) | 1.0.1 | python3 |
 | [orjson](https://pypi.org/project/orjson) | 3.11.7 | python3 |
 | [packaging](https://pypi.org/project/packaging) | 26.0 | python3_core |

--- a/layers/layer0_core/0025_openssl/Makefile.mk
+++ b/layers/layer0_core/0025_openssl/Makefile.mk
@@ -2,10 +2,10 @@ include ../../../adm/root.mk
 include ../../package.mk
 
 export NAME=openssl
-export VERSION=3.5.5
+export VERSION=3.6.2
 export EXTENSION=tar.gz
 export CHECKTYPE=MD5
-export CHECKSUM=9c86d929c3d1067e2c88239d7d1ce81b
+export CHECKSUM=f27e8f53ac612bb0e3e781a45799fb90
 DESCRIPTION=\
 OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the TLS (formerly SSL), DTLS and QUIC protocols
 WEBSITE=https://www.openssl.org/

--- a/layers/layer0_core/0025_openssl/sources
+++ b/layers/layer0_core/0025_openssl/sources
@@ -1,1 +1,1 @@
-https://github.com/openssl/openssl/releases/download/openssl-3.5.5/openssl-3.5.5.tar.gz
+https://github.com/openssl/openssl/releases/download/openssl-3.6.2/openssl-3.6.2.tar.gz


### PR DESCRIPTION
CVE fixed : 
- [CVE-2026-31790](https://openssl-library.org/news/vulnerabilities/#CVE-2026-31790)
- [CVE-2026-2673](https://openssl-library.org/news/vulnerabilities/#CVE-2026-2673)
- [CVE-2026-28387](https://openssl-library.org/news/vulnerabilities/#CVE-2026-28387)
- [CVE-2026-28388](https://openssl-library.org/news/vulnerabilities/#CVE-2026-28388)
- [CVE-2026-28389](https://openssl-library.org/news/vulnerabilities/#CVE-2026-28389)
- [CVE-2026-28390](https://openssl-library.org/news/vulnerabilities/#CVE-2026-28390)
- [CVE-2026-31789](https://openssl-library.org/news/vulnerabilities/#CVE-2026-31789)