### PR TITLE
feat: bump redis from 7.4.7 to 7.4.9 (fix 3 high CVEs)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -249,7 +249,7 @@
 | [pyyaml_env_tag](https://github.com/waylan/pyyaml-env-tag) | 0.1 | python3_devtools |
 | [pyzmq](https://pyzmq.readthedocs.org) | 25.1.1 | python3_circus |
 | [readline](https://www.gnu.org/software/readline) | 8.2.13 | core |
-| [redis](http://redis.io) | 7.4.7 | core |
+| [redis](http://redis.io) | 7.4.9 | core |
 | [redis](https://github.com/redis/redis-py) | 7.2.2 | python3 |
 | [referencing](https://github.com/python-jsonschema/referencing) | 0.36.2 | python3 |
 | [regex](https://github.com/mrabarnett/mrab-regex) | 2024.11.6 | python3 |

--- a/layers/layer0_core/0100_redis/Makefile.mk
+++ b/layers/layer0_core/0100_redis/Makefile.mk
@@ -2,10 +2,10 @@ include ../../../adm/root.mk
 include ../../package.mk
 
 export NAME=redis
-export VERSION=7.4.7
+export VERSION=7.4.9
 export EXTENSION=tar.gz
 export CHECKTYPE=MD5
-export CHECKSUM=0a22d4a6d906a4588603d188b642e85d
+export CHECKSUM=5653ab287dda0ec65b04da7750ce6888
 DESCRIPTION=\
 REDIS is an in-memory data structure store, used as a database, cache \
 and message broker

--- a/layers/layer0_core/0100_redis/sources
+++ b/layers/layer0_core/0100_redis/sources
@@ -1,1 +1,1 @@
-http://download.redis.io/releases/redis-7.4.7.tar.gz
+http://download.redis.io/releases/redis-7.4.9.tar.gz


### PR DESCRIPTION
CVE fixed :
- CVE-2026-23479
- CVE-2026-23631
- CVE-2026-25243