### PR TITLE
build: move Mako from python3_devtools to python3

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -135,7 +135,7 @@
 | [lua-resty-statsd](https://github.com/metwork-framework/lua-resty-statsd) | 0.0.3 | openresty |
 | [lunr](https://pypi.org/project/lunr) | 0.8.0 | python3_devtools |
 | [lxml](https://lxml.de/) | 6.1.0 | python3 |
-| [Mako](https://www.makotemplates.org/) | 1.3.12 | python3_devtools |
+| [Mako](https://www.makotemplates.org/) | 1.3.12 | python3 |
 | [markdown-it-py](https://github.com/executablebooks/markdown-it-py) | 3.0.0 | python3 |
 | [Markdown](https://Python-Markdown.github.io/) | 3.10.2 | python3 |
 | [MarkupSafe](https://pypi.org/project/MarkupSafe) | 3.0.2 | python3 |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -71,6 +71,7 @@ jsonschema_specifications==2024.10.1
 lark==1.1.8
 lazy-import==0.2.2
 lxml==6.1.0
+Mako==1.3.12
 Markdown==3.10.2
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2

--- a/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
@@ -27,7 +27,6 @@ lazy-object-proxy==1.10.0
 libcst==1.8.6
 livereload==2.7.1
 lunr==0.8.0
-Mako==1.3.12
 mccabe==0.7.0
 mergedeep==1.3.4
 mkdocs==1.6.1


### PR DESCRIPTION
Mako is a required dependency in layer python3_ia