### PR TITLE
feat: bump pillow from 12.2.0 to 12.3.0 (fix 10 high CVEs)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -190,7 +190,7 @@
 | [pgbouncer](https://www.pgbouncer.org/) | 1.25.1 | scientific_core |
 | [pickleshare](https://github.com/pickleshare/pickleshare) | 0.7.5 | python3 |
 | [pika](https://pika.readthedocs.io) | 1.3.2 | python3 |
-| [pillow](https://python-pillow.github.io) | 12.2.0 | python3 |
+| [pillow](https://python-pillow.github.io) | 12.3.0 | python3 |
 | [pip](https://pip.pypa.io/) | 26.1.2 | python3_core |
 | [pipdeptree](https://github.com/tox-dev/pipdeptree) | 2.26.0 | python3_devtools |
 | [platformdirs](https://github.com/tox-dev/platformdirs) | 4.5.0 | python3_core |

--- a/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer2_python3/0500_extra_python_packages/requirements3.txt
@@ -93,7 +93,7 @@ pbr==7.0.3
 pexpect==4.9.0
 pickleshare==0.7.5
 pika==1.3.2
-Pillow==12.2.0
+Pillow==12.3.0
 poyo==0.5.0
 prompt-toolkit==3.0.50
 propcache==0.3.0


### PR DESCRIPTION
CVE fixed :
- CVE-2026-54058 (high)
- CVE-2026-54059 (high)
- CVE-2026-54060 (high)
- CVE-2026-55379 (high)
- CVE-2026-55380 (high)
- CVE-2026-55798 (moderate)
- CVE-2026-59197 (high)
- CVE-2026-59198 (moderate)
- CVE-2026-59199 (high)
- CVE-2026-59200 (high)
- CVE-2026-59203 (moderate)
- CVE-2026-59204 (high)
- CVE-2026-59205 (high)