### PR TITLE
feat: bump pymdown-extensions to 11.0.1 (fix moderate CVE-2026-61632)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -154,7 +154,7 @@
 | [mkdocs-get-deps](https://pypi.org/project/mkdocs-get-deps) | 0.2.0 | python3_devtools |
 | [mkdocs-macros-plugin](https://github.com/fralau/mkdocs_macros_plugin) | 1.3.7 | python3_devtools |
 | [mkdocs-material-extensions](https://github.com/facelessuser/mkdocs-material-extensions) | 1.3.1 | python3_devtools |
-| [mkdocs-material](https://pypi.org/project/mkdocs-material) | 9.6.9 | python3_devtools |
+| [mkdocs-material](https://pypi.org/project/mkdocs-material) | 9.7.7 | python3_devtools |
 | [mkdocs](https://pypi.org/project/mkdocs) | 1.6.1 | python3_devtools |
 | [mock](http://mock.readthedocs.org/en/latest/) | 5.2.0 | python3_devtools |
 | [more-itertools](https://github.com/more-itertools/more-itertools) | 10.6.0 | python3_devtools |
@@ -227,7 +227,7 @@
 | [pyinstaller-hooks-contrib](https://github.com/pyinstaller/pyinstaller-hooks-contrib) | 2026.5 | python3_devtools |
 | [pyinstaller](https://pyinstaller.org) | 6.20.0 | python3_devtools |
 | [pylint](https://github.com/pylint-dev/pylint) | 3.3.6 | python3_devtools |
-| [pymdown-extensions](https://github.com/facelessuser/pymdown-extensions) | 10.21.3 | python3_devtools |
+| [pymdown-extensions](https://github.com/facelessuser/pymdown-extensions) | 11.0.1 | python3_devtools |
 | [PyNaCl](https://github.com/pyca/pynacl/) | 1.6.2 | python3 |
 | [pyparsing](https://github.com/pyparsing/pyparsing/) | 3.2.1 | python3_core |
 | [pyproject-api](https://pyproject-api.readthedocs.io) | 1.9.1 | python3_devtools |

--- a/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
@@ -35,7 +35,7 @@ mkdocs-awesome-nav==3.0.0
 mkdocs-exclude==1.0.2
 mkdocs-get-deps==0.2.0
 mkdocs-macros-plugin==1.3.7
-mkdocs-material==9.6.9
+mkdocs-material==9.7.7
 mkdocs-material-extensions==1.3.1
 mock==5.2.0
 more-itertools==10.6.0
@@ -53,7 +53,7 @@ pyflakes==3.2.0
 pyinstaller-hooks-contrib==2026.5
 pyinstaller==6.20.0
 pylint==3.3.6
-pymdown-extensions==10.21.3
+pymdown-extensions==11.0.1
 pyproject-api==1.9.1
 pytest==9.0.3
 pytest-asyncio==1.3.0


### PR DESCRIPTION
also upgrade mkdocs-material to 9.7.7