### PR TITLE
feat: bump pgbouncer to 1.25.2 (fix high CVE-2026-6664 & CVE-2026-6665)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -187,7 +187,7 @@
 | [pg_cron](https://github.com/citusdata/pg_cron) | 1.6.7 | scientific_core |
 | [pg_partman](https://github.com/pgpartman/pg_partman) | 5.2.4 | scientific_core |
 | [pg_uuidv7](https://pgxn.org/dist/pg_uuidv7/) | 1.7.0 | scientific_core |
-| [pgbouncer](https://www.pgbouncer.org/) | 1.25.1 | scientific_core |
+| [pgbouncer](https://www.pgbouncer.org/) | 1.25.2 | scientific_core |
 | [pickleshare](https://github.com/pickleshare/pickleshare) | 0.7.5 | python3 |
 | [pika](https://pika.readthedocs.io) | 1.3.2 | python3 |
 | [pillow](https://python-pillow.github.io) | 12.3.0 | python3 |

--- a/layers/layer1_scientific_core/0009_pgbouncer/Makefile.mk
+++ b/layers/layer1_scientific_core/0009_pgbouncer/Makefile.mk
@@ -2,10 +2,10 @@ include ../../../adm/root.mk
 include ../../package.mk
 
 export NAME=pgbouncer
-export VERSION=1.25.1
+export VERSION=1.25.2
 export EXTENSION=tar.gz
 export CHECKTYPE=MD5
-export CHECKSUM=db042d282b8cb69fd6429cf5785bb008
+export CHECKSUM=9689b5ec4a60c25dc7791962b2863ca6
 DESCRIPTION=\
 PGBOUNCER is a lightweight connection pooler for PostgreSQL
 WEBSITE=https://www.pgbouncer.org/

--- a/layers/layer1_scientific_core/0009_pgbouncer/sources
+++ b/layers/layer1_scientific_core/0009_pgbouncer/sources
@@ -1,1 +1,1 @@
-https://www.pgbouncer.org/downloads/files/1.25.1/pgbouncer-1.25.1.tar.gz
+https://www.pgbouncer.org/downloads/files/1.25.2/pgbouncer-1.25.2.tar.gz


### PR DESCRIPTION
Also fix medium CVE-2026-6666 and CVE-2026-6667