### PR TITLE
feat: bump GitPython to 3.1.58 (fix high GHSA-3f7w-8rr8-f37f)

### DIFF
--- a/.metwork-framework/components.md
+++ b/.metwork-framework/components.md
@@ -81,7 +81,7 @@
 | [ghp-import](https://github.com/c-w/ghp-import) | 2.1.0 | python3_devtools |
 | [gitdb](https://github.com/gitpython-developers/gitdb) | 4.0.12 | python3_devtools |
 | [gitignore_parser](https://github.com/mherrmann/gitignore_parser) | 0.1.13 | python3 |
-| [GitPython](https://github.com/gitpython-developers/GitPython) | 3.1.54 | python3_devtools |
+| [GitPython](https://github.com/gitpython-developers/GitPython) | 3.1.58 | python3_devtools |
 | [h11](https://github.com/python-hyper/h11) | 0.16.0 | python3 |
 | [hdf4](https://www.hdfgroup.org) | 4.3.1 | scientific_core |
 | [hdf5](https://www.hdfgroup.org) | 2.1.1 | scientific_core |

--- a/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
+++ b/layers/layer7_python3_devtools/0500_extra_python_packages/requirements3.txt
@@ -17,7 +17,7 @@ flake8-docstrings==1.7.0
 freezegun==1.5.1
 ghp-import==2.1.0
 gitdb==4.0.12
-GitPython==3.1.54
+GitPython==3.1.58
 hjson==3.1.0
 identify==2.6.9
 iniconfig==2.1.0


### PR DESCRIPTION
Also fixed moderate GHSA-539m-9xh6-q6rr and GHSA-p538-c434-8v24